### PR TITLE
Constants & Pathes

### DIFF
--- a/meta-box.php
+++ b/meta-box.php
@@ -102,8 +102,7 @@ if ( !class_exists( 'RW_Meta_Box' ) ) {
 			$dir		= basename( RWMB_DIR );
 			$dir		= "{$dir}/lang";
 			$domain		= RWMB_TEXTDOMAIN;
-			$local		= get_local();
-			$l10n_file	= "{$dir}/{$domain}-{$local}.mo";
+			$l10n_file	= "{$dir}/{$domain}-{$GLOBALS['locale']}.mo";
 
 			// in plugins directory
 			load_textdomain( $domain, $l10n_file );


### PR DESCRIPTION
The patch/pull requests checks if the constants for dir pathes were already defined before. This allows for overriding those in example a theme.

I also added translation file support for themes. Overall this makes it possible to pack it with a theme an not only allows to use it as a plugin.

Signed-off-by: franz-josef-kaiser 24-7@gmx.net
