### PR TITLE
Alternate solution to clone code

### DIFF
--- a/demo/demo.php
+++ b/demo/demo.php
@@ -179,7 +179,8 @@ $meta_boxes[] = array(
 		array(
 			'name' => 'Full name',          // Field name
 			'desc' => 'Format: First Last', // Field description, optional
-			'id' => $prefix . 'fname[]',    // Field id, i.e. the meta key
+			'id' => $prefix . 'fname',    // Field id, i.e. the meta key
+			'clone' => true,
 			                                // Note: Append[] to field id to make the field cloneable (i.e. have multiple value)
 			'type' => 'text',               // Field type: text box
 			'std' => 'Anh Tran'             // Default value, optional
@@ -188,7 +189,8 @@ $meta_boxes[] = array(
 			'name' => 'DOB',
 			'id' => $prefix . 'dob',
 			'type' => 'date',               // File type: date
-			'format' => 'd MM, yy'          // Date format, default yy-mm-dd. Optional. See: http://goo.gl/po8vf
+			'format' => 'd MM, yy',          // Date format, default yy-mm-dd. Optional. See: http://goo.gl/po8vf
+			'clone' => true
 		),
 		array(
 			'name' => 'Gender',

--- a/inc/fields/checkbox.php
+++ b/inc/fields/checkbox.php
@@ -31,7 +31,8 @@ if ( ! class_exists( 'RWMB_Checkbox_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$checked = checked( ! empty( $meta ), true, false );
-			$name    = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id      = " id='{$field['id']}'";
 			$html    = "<input type='checkbox' class='rwmb-checkbox'{$name}{$id}{$checked} />";
 

--- a/inc/fields/color.php
+++ b/inc/fields/color.php
@@ -28,9 +28,11 @@ if ( ! class_exists( 'RWMB_Color_Field' ) )
 		{
 			if ( empty( $meta ) )
 				$meta = '#';
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 
 			$html = <<<HTML
-<input class="rwmb-color" type="text" name="{$field['id']}" id="{$field['id']}" value="{$meta}" size="8" />
+<input class="rwmb-color" type="text" {$name} id="{$field['id']}" value="{$meta}" size="8" />
 <a href="#" class="rwmb-color-select" rel="{$field['id']}">%s</a>
 <div class="rwmb-color-picker" rel="{$field['id']}"></div>
 HTML;

--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -30,7 +30,8 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name   = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id     = " id='{$field['id']}'";
 			$format = " rel='{$field['format']}'";
 			$val    = " value='{$meta}'";

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -36,7 +36,8 @@ if ( ! class_exists( 'RWMB_Datetime_Field' ) )
 		 */
 		static function html( $html, $meta, $field )
 		{
-			$name  = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id    = " id='{$field['id']}'";
 			$rel   = " rel='{$field['format']}'";
 			$val   = " value='$meta'";

--- a/inc/fields/password.php
+++ b/inc/fields/password.php
@@ -16,7 +16,8 @@ if ( ! class_exists( 'RWMB_Password_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$val   = " value='{$meta}'";
-			$name  = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<input type='password' class='rwmb-password'{$name}{$id}{$val} size='30' />";
 

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -29,7 +29,8 @@ if ( ! class_exists( 'RWMB_Select_Field' ) )
 				$meta = (array) $meta;
 
 			$name  = " name='{$field['id']}";
-			$name .= $field['multiple'] ? "[]' id='{$field['id']}' multiple='multiple'" : "'";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
+			$name .= $field['multiple'] ? " id='{$field['id']}' multiple='multiple'" : "" ;
 			$html  = "<select class='rwmb-select'{$name} >";
 			foreach ( $field['options'] as $key => $value ) 
 			{

--- a/inc/fields/slider.php
+++ b/inc/fields/slider.php
@@ -30,7 +30,8 @@ if ( ! class_exists( 'RWMB_Slider_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$id	     = " id='{$field['id']}'";
-			$name    = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$val     = " value='{$meta}'";
 			$for     = " for='{$field['id']}'";
 			$format	 = " rel='{$field['format']}'";

--- a/inc/fields/text.php
+++ b/inc/fields/text.php
@@ -16,7 +16,8 @@ if ( ! class_exists( 'RWMB_Text_Field' ) )
 		static function html( $html, $meta, $field ) 
 		{
 			$val   = " value='{$meta}'";
-			$name  = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<input type='text' class='rwmb-text'{$name}{$id}{$val} size='30' />";
 

--- a/inc/fields/textarea.php
+++ b/inc/fields/textarea.php
@@ -15,7 +15,8 @@ if ( ! class_exists( 'RWMB_Textarea_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name  = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<textarea class='rwmb-textarea large-text'{$name}{$id} cols='60' rows='10'>{$meta}</textarea>";
 

--- a/inc/fields/time.php
+++ b/inc/fields/time.php
@@ -36,7 +36,8 @@ if ( ! class_exists( 'RWMB_Time_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name  = " name='{$field['id']}'";
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 			$id    = " id='{$field['id']}'";
 			$rel   = " rel='{$field['format']}'";
 			$val   = " value='$meta'";

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -58,10 +58,12 @@ if ( ! class_exists( 'RWMB_Wysiwyg_Field' ) )
 		static function html( $html, $meta, $field ) 
 		{
 			global $wp_version;
+			$name = "name='{$field['id']}";
+			$name .= ( $field['multiple'] || $field['clone'])? "[]'" : "'";
 
 			if ( version_compare( $wp_version, '3.2.1' ) < 1 ) 
 			{
-				return "<textarea class='rwmb-wysiwyg theEditor large-text' name='{$field['id']}' id='{$field['id']}' cols='60' rows='10'>$meta</textarea>";
+				return "<textarea class='rwmb-wysiwyg theEditor large-text' {$name} id='{$field['id']}' cols='60' rows='10'>$meta</textarea>";
 			} 
 			else 
 			{

--- a/meta-box.php
+++ b/meta-box.php
@@ -175,7 +175,7 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 			foreach ( $this->fields as $field )
 			{
 				$type = $field['type'];
-				$id = self::get_clean_id( $field );
+				$id = $field['id'];
 
 				$meta = get_post_meta( $post->ID, $id, ! $field['multiple'] );
 
@@ -322,7 +322,7 @@ HTML;
 		 */
 		static function end_html( $html, $meta, $field )
 		{
-			$id   = self::get_clean_id( $field );
+			$id   = $field['id'];
 			$desc = !empty( $field[ 'desc' ] ) ? "<p id='{$id}_description' class='description'>{$field['desc']}</p>" : '';
 
 			$buttons = '';
@@ -355,7 +355,7 @@ HTML;
 		 */
 		static function add_delete_clone_button( $html, $field, $meta_data )
 		{
-			$id = self::get_clean_id( $field );
+			$id = $field['id'];
 
 			$button = get_submit_button(
 				__( '&#8211;', RWMB_TEXTDOMAIN ),
@@ -404,7 +404,7 @@ HTML;
 
 			foreach ( $this->fields as $field )
 			{
-				$name = self::get_clean_id( $field );
+				$name = $field['id'];
 				$old  = get_post_meta( $post_id, $name, ! $field['multiple'] );
 				$new  = isset( $_POST[ $name ] ) ? $_POST[ $name ] : ( $field['multiple'] ? array() : '' );
 
@@ -434,7 +434,7 @@ HTML;
 		 */
 		static function save( $new, $old, $post_id, $field )
 		{
-			$name = self::get_clean_id( $field );
+			$name = $field['id'];
 
 			delete_post_meta( $post_id, $name );
 			if ( '' === $new || array() === $new )
@@ -476,12 +476,15 @@ HTML;
 			// Set default values for fields
 			foreach ( $meta_box['fields'] as &$field )
 			{
-				$multiple = in_array( $field['type'], array( 'checkbox_list', 'file', 'image' ) );
+				$clone 	  = (isset($field['clone']) ? $field['clone'] : false);
+				$multiple = in_array( $field['type'], array( 'checkbox_list', 'file', 'image' ) ) ;
 				$std      = $multiple ? array() : '';
 				$format   = 'date' === $field['type'] ? 'yy-mm-dd' : ( 'time' === $field['type'] ? 'hh:mm' : '' );
+				
 
 				$field = wp_parse_args( $field, array(
 					'multiple' => $multiple,
+					'clone' => $clone,
 					'std'      => $std,
 					'desc'     => '',
 					'format'   => $format
@@ -597,7 +600,7 @@ HTML;
 			$saved = false;
 			foreach ( $fields as $field )
 			{
-				if ( get_post_meta( $post_id, self::get_clean_id( $field['id'] ), ! $field['multiple'] ) )
+				if ( get_post_meta( $post_id, $field['id'], ! $field['multiple'] ) )
 				{
 					$saved = true;
 					break;
@@ -624,17 +627,6 @@ HTML;
 			return $class;
 		}
 
-		/**
-		 * Helper function for multi/clone field IDs
-		 *
-		 * @param  array $field
-		 *
-		 * @return string Clean field ID without the trailing "[]"
-		 */
-		static function get_clean_id( $field )
-		{
-			return str_replace( '[]', '', $field['id'] );
-		}
 
 		/**
 		 * Helper function to check for multi/clone field IDs
@@ -645,7 +637,7 @@ HTML;
 		 */
 		static function is_cloneable( $field )
 		{
-			return false !== strpos( $field['id'], '[]' );
+			return $field['clone'];
 		}
 	}
 }


### PR DESCRIPTION
I found that if a select field was both multiple and clone, the id was given two sets of [].  Changed th code to fix this.  Instead of adding [] to your field id, just add the clone option instead: 

``` php
...
'fields' => array(                    // List of meta fields
        array(
            'name' => 'Full name',          // Field name
            'desc' => 'Format: First Last', // Field description, optional
            'id' => $prefix . 'fname',    // Field id, i.e. the meta key
            'clone' =>  true,              //Add to make the field cloneable (i.e. have multiple value)
            'type' => 'text',               // Field type: text box
            'std' => 'Anh Tran'             // Default value, optional
        ),
...
```
