### PR TITLE
Fixing a brain fart and adding customizable meta data retrieval

### DIFF
--- a/demo/demo.php
+++ b/demo/demo.php
@@ -78,8 +78,6 @@ if ( !class_exists( 'RWMB_Taxonomy_Field' ) )
 
 			$options = $field['options'];
 
-			$meta = wp_get_post_terms( $post->ID, $options['taxonomy'], array( 'fields' => 'ids' ) );
-			$meta = is_array( $meta ) ? $meta : ( array ) $meta;
 			$terms = get_terms( $options['taxonomy'], $options['args'] );
 
 			$html = '';
@@ -150,6 +148,24 @@ if ( !class_exists( 'RWMB_Taxonomy_Field' ) )
 		static function save( $new, $old, $post_id, $field )
 		{
 			wp_set_post_terms( $post_id, $new, $field['options']['taxonomy'] );
+		}
+		
+		/**
+		 * Standard meta retrieval
+		 *
+		 * @param mixed 	$meta
+		 * @param int		$post_id
+		 * @param array  	$field
+		 * @param bool  	$saved
+		 *
+		 * @return mixed
+		 */
+		static function meta( $meta, $post_id, $saved, $field )
+		{
+			$options = $field['options'];
+			$meta = wp_get_post_terms( $post_id, $options['taxonomy'], array( 'fields' => 'ids' ) );
+			$meta = is_array( $meta ) ? $meta : ( array ) $meta;
+			return $meta;
 		}
 	}
 }

--- a/inc/fields/checkbox.php
+++ b/inc/fields/checkbox.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'RWMB_Checkbox_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$checked = checked( ! empty( $meta ), true, false );
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id      = " id='{$field['id']}'";
 			$html    = "<input type='checkbox' class='rwmb-checkbox'{$name}{$id}{$checked} />";
 

--- a/inc/fields/checkbox_list.php
+++ b/inc/fields/checkbox_list.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'RWMB_Checkbox_List_Field' ) )
 			foreach ( $field['options'] as $key => $value ) 
 			{
 				$checked = checked( in_array( $key, $meta ), true, false );
-				$name = "name='{$field['name']}'";
+				$name = "name='{$field['field_name']}'";
 				$val     = " value='{$key}'";
 				$html[]  = "<input type='checkbox' class='rwmb-checkbox-list'{$name}{$val}{$checked} /> {$value}";
 			}

--- a/inc/fields/color.php
+++ b/inc/fields/color.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'RWMB_Color_Field' ) )
 		{
 			if ( empty( $meta ) )
 				$meta = '#';
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 
 			$html = <<<HTML
 <input class="rwmb-color" type="text" {$name} id="{$field['id']}" value="{$meta}" size="8" />

--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id     = " id='{$field['id']}'";
 			$format = " rel='{$field['format']}'";
 			$val    = " value='{$meta}'";

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'RWMB_Datetime_Field' ) )
 		 */
 		static function html( $html, $meta, $field )
 		{
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id    = " id='{$field['id']}'";
 			$rel   = " rel='{$field['format']}'";
 			$val   = " value='$meta'";

--- a/inc/fields/password.php
+++ b/inc/fields/password.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'RWMB_Password_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$val   = " value='{$meta}'";
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<input type='password' class='rwmb-password'{$name}{$id}{$val} size='30' />";
 

--- a/inc/fields/plupload-image.php
+++ b/inc/fields/plupload-image.php
@@ -171,6 +171,7 @@ HTML;
 			$i18n_edit		= _x( 'Edit', 'image upload', RWMB_TEXTDOMAIN );
 			$i18n_title		= _x( 'Upload files', 'image upload', RWMB_TEXTDOMAIN );
 			$i18n_more		= _x( 'Add another file', 'image upload', RWMB_TEXTDOMAIN );
+
 			// Filter to change the drag & drop box background string
 			$i18n_drop		= apply_filters( 'rwmb_upload_drop_string', _x( 'Drop images here', 'image upload', RWMB_TEXTDOMAIN ) );
 			$i18n_select	= _x( 'Select Files', RWMB_TEXTDOMAIN );
@@ -180,65 +181,37 @@ HTML;
 			$html .= wp_nonce_field( "rwmb-reorder-images_{$field['id']}", "nonce-reorder-images_{$field['id']}", false, false );
 			$html .= "<input type='hidden' class='field-id rwmb-image-prefix' value='{$field['id']}' />";
 
-			// Re-arrange images with 'menu_order', thanks Onur
-			if ( ! empty( $meta ) )
+			//Uploaded images
+			$html .= "<div id='{$img_prefix}-container'>";
+			$html .= "<h4 class='rwmb-uploaded-title'>{$i18n_msg}</h4>";
+			$html .= "<ul class='rwmb-images rwmb-uploaded'>";
+			
+			foreach ( $meta as $image )
 			{
-				$html .= "<div id='{$img_prefix}-container'>";
-				$html .= "<h4 class='rwmb-uploaded-title'>{$i18n_msg}</h4>";
-				$html .= "<ul class='rwmb-images rwmb-uploaded'>";
-
-				$meta	= implode( ',', $meta );
-				// Need to suppress errors if there are no images to far
-				if (
-					empty( $meta )
-					AND ( defined('WP_DEBUG') AND WP_DEBUG )
-					AND ( defined('WP_DEBUG_DISPLAY') AND WP_DEBUG_DISPLAY )
-				)
-					$wpdb->suppress_errors = true;
-
-				$images	= $wpdb->get_col( "
-					SELECT ID
-					FROM $wpdb->posts
-					WHERE post_type = 'attachment'
-					AND ID in ($meta)
-					ORDER BY menu_order
-					ASC
-				" );
-
-				// Move debug back in to not interrupt other debug stuff from other plugins
-				if (
-					defined('WP_DEBUG')
-					AND WP_DEBUG
-				)
-					$wpdb->suppress_errors = false;
-
-				foreach ( $images as $image )
-				{
-					$src = wp_get_attachment_image_src( $image, 'thumbnail' );
-					$src = $src[0];
-					$link = get_edit_post_link( $image );
-
-					$html .= "
-					<li id='item_{$image}'>
-						<img src='{$src}' />
-						<div class='rwmb-image-bar'>
-							<a title='{$i18n_edit}' class='rwmb-edit-file' href = '{$link}' >{$i18n_edit}</a> |
-							<a title='{$i18n_del_file}' class='rwmb-delete-file' href='#' rel='{$image}'>{$i18n_delete}</a>
-						</div>
-					</li>";
-				}
-
+				$src = wp_get_attachment_image_src( $image, 'thumbnail' );
+				$src = $src[0];
+				$link = get_edit_post_link( $image );
 
 				$html .= "
-				<li id='item_' class='hidden rwmb-image-template'>
-					<img id='' class='rwmb-image' src='' />
-					<div class='rwmb-image-bar hidden'>
-						<a title='{$i18n_edit}' class='rwmb-edit-file' href = ''>{$i18n_edit}</a> |
-						<a title='{$i18n_del_file}' class='rwmb-delete-file' href='#' rel=''>{$i18n_delete}</a>
+				<li id='item_{$image}'>
+					<img src='{$src}' />
+					<div class='rwmb-image-bar'>
+						<a title='{$i18n_edit}' class='rwmb-edit-file' href = '{$link}' >{$i18n_edit}</a> |
+						<a title='{$i18n_del_file}' class='rwmb-delete-file' href='#' rel='{$image}'>{$i18n_delete}</a>
 					</div>
 				</li>";
-				$html .= '</ul>';
 			}
+			//Template image node
+			$html .= "
+			<li id='item_' class='hidden rwmb-image-template'>
+				<img id='' class='rwmb-image' src='' />
+				<div class='rwmb-image-bar hidden'>
+					<a title='{$i18n_edit}' class='rwmb-edit-file' href = ''>{$i18n_edit}</a> |
+					<a title='{$i18n_del_file}' class='rwmb-delete-file' href='#' rel=''>{$i18n_delete}</a>
+				</div>
+			</li>";
+			$html .= '</ul>';
+			
 
 			// Show form upload
 			$html .= "

--- a/inc/fields/radio.php
+++ b/inc/fields/radio.php
@@ -21,7 +21,7 @@ if ( ! class_exists( 'RWMB_Radio_Field' ) )
 				$checked = checked( $meta, $key, false );
 				$id		 = strstr( $field['id'], '[]' ) ? str_replace( '[]', "-{$key}[]", $field['id'] ) : $field['id'];
 				$id		 = " id='{$id}'";
-				$name = "name='{$field['name']}'";
+				$name = "name='{$field['field_name']}'";
 				$val     = " value='{$key}'";
 				$html   .= "<input type='radio' class='rwmb-radio'{$name}{$id}{$val}{$checked} /> {$value}";
 			}

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'RWMB_Select_Field' ) )
 			if ( ! is_array( $meta ) )
 				$meta = (array) $meta;
 
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id = "id='{$field['id']}'";
 			$name .= $field['multiple'] ? " multiple='multiple'" : "" ;
 			$html  = "<select class='rwmb-select'{$name} {$id} >";

--- a/inc/fields/slider.php
+++ b/inc/fields/slider.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'RWMB_Slider_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$id	     = " id='{$field['id']}'";
-			$name	 = "name='{$field['name']}'";
+			$name	 = "name='{$field['field_name']}'";
 			$val     = " value='{$meta}'";
 			$for     = " for='{$field['id']}'";
 			$format	 = " rel='{$field['format']}'";

--- a/inc/fields/text.php
+++ b/inc/fields/text.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'RWMB_Text_Field' ) )
 		static function html( $html, $meta, $field ) 
 		{
 			$val   = " value='{$meta}'";
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<input type='text' class='rwmb-text'{$name}{$id}{$val} size='30' />";
 

--- a/inc/fields/textarea.php
+++ b/inc/fields/textarea.php
@@ -15,7 +15,7 @@ if ( ! class_exists( 'RWMB_Textarea_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id    = " id='{$field['id']}'";
 			$html .= "<textarea class='rwmb-textarea large-text'{$name}{$id} cols='60' rows='10'>{$meta}</textarea>";
 

--- a/inc/fields/time.php
+++ b/inc/fields/time.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'RWMB_Time_Field' ) )
 		 */
 		static function html( $html, $meta, $field ) 
 		{
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 			$id    = " id='{$field['id']}'";
 			$rel   = " rel='{$field['format']}'";
 			$val   = " value='$meta'";

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'RWMB_Wysiwyg_Field' ) )
 		static function html( $html, $meta, $field ) 
 		{
 			global $wp_version;
-			$name = "name='{$field['name']}'";
+			$name = "name='{$field['field_name']}'";
 
 			if ( version_compare( $wp_version, '3.2.1' ) < 1 ) 
 			{

--- a/meta-box.php
+++ b/meta-box.php
@@ -181,6 +181,8 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 
 				// Use $field['std'] only when the meta box hasn't been saved (i.e. the first time we run)
 				$meta = ( ! $saved && '' === $meta || array() === $meta ) ? $field['std'] : $meta;
+				
+				$meta = self::apply_field_class_filters( $field, 'meta', '', $post->ID, $saved );
 
 				// Escape attributes for non-wysiwyg fields
 				if ( 'wysiwyg' !== $type )
@@ -307,6 +309,25 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 HTML;
 
 			return $html;
+		}
+		
+		/**
+		 * Standard meta retrieval
+		 *
+		 * @param mixed 	$meta
+		 * @param int		$post_id
+		 * @param array  	$field
+		 * @param bool  	$saved
+		 *
+		 * @return mixed
+		 */
+		static function meta( $meta, $post_id, $saved, $field )
+		{		
+			$meta = get_post_meta( $post_id, $field['id'], ! $field['multiple'] );
+			// Use $field['std'] only when the meta box hasn't been saved (i.e. the first time we run)
+			$meta = ( ! $saved && '' === $meta || array() === $meta ) ? $field['std'] : $meta;
+			
+			return $meta;
 		}
 
 		/**
@@ -488,7 +509,7 @@ HTML;
 					'format'   => $format
 				) );
 				
-				$field['name'] = $field['id'] . (( $field['multiple'] || $field['clone'])? "[]" : "");
+				$field['field_name'] = $field['id'] . (( $field['multiple'] || $field['clone'])? "[]" : "");
 
 				// Allow field class add/change default field values
 				$field = self::apply_field_class_filters( $field, 'normalize_field', $field );


### PR DESCRIPTION
1. Fixes mistake from the last commit.  The normalize function populates 'field_name', which is then used to populate the name attribute of the input fields.
2.  The way the plugin pulls meta data is overhauled.  Meta data is now pulled by the meta function.  Each field can now have their own way of pulling meta data.  Please see the taxonomy example in the demo file for details
