### PR TITLE
Change $meta order using the posts 'menu_order'

### DIFF
--- a/inc/fields/image.php
+++ b/inc/fields/image.php
@@ -105,6 +105,15 @@ if ( ! class_exists( 'RWMB_Image_Field' ) )
 				$html .= "<h4>{$i18n_msg}</h4>";
 				$html .= "<ul class='rwmb-images rwmb-uploaded'>";
 
+				// Change $meta order using the posts 'menu_order'
+				$meta_menu_order = array();
+				foreach ($meta as $post_id) {
+					$post_meta = get_post($post_id);
+					$meta_menu_order[$post_meta->menu_order] = $post_id;
+				}
+				ksort($meta_menu_order);
+				$meta = $meta_menu_order;
+
 				foreach ( $meta as $image )
 				{
 					$src = wp_get_attachment_image_src( $image, 'thumbnail' );

--- a/inc/fields/plupload-image.php
+++ b/inc/fields/plupload-image.php
@@ -142,6 +142,15 @@ HTML;
 			if ( ! is_array( $meta ) )
 				$meta = ( array ) $meta;
 
+			// Change $meta order using the posts 'menu_order'
+			$meta_menu_order = array();
+			foreach ($meta as $post_id) {
+				$post_meta = get_post($post_id);
+				$meta_menu_order[$post_meta->menu_order] = $post_id;
+			}
+			ksort($meta_menu_order);
+			$meta = $meta_menu_order;
+
 			$i18n_msg   = _x( 'Uploaded files', 'image upload', 'rwmb' );
 			$i18n_title = _x( 'Upload files', 'image upload', 'rwmb' );
 


### PR DESCRIPTION
Get the real order ('menu_order') to display the uploaded images (bug only inside the meta-box).

Issue: https://github.com/rilwis/meta-box/issues/121
