### PR TITLE
Customize javascript options for date picker

### DIFF
--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -39,8 +39,9 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 			$value  = " value='{$meta}'";
 			$size   = " size='{$field['size']}'";
 			$format = " rel='{$field['format']}'";
+			$options = isset($field['js']) ? " data-options='" . json_encode($field['js']) . "'" : "";
 
-			$html   = "<input type='text' class='rwmb-date'{$name}{$id}{$value}{$size}{$format} />";
+			$html   = "<input type='text' class='rwmb-date'{$name}{$id}{$value}{$size}{$format}{$options} />";
 
 			return $html;
 		}

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -43,7 +43,8 @@ if ( ! class_exists( 'RWMB_Datetime_Field' ) )
 			$value  = " value='{$meta}'";
 			$size   = " size='{$field['size']}'";
 			$format = " rel='{$field['format']}'";
-			$html .= "<input type='text' class='rwmb-datetime'{$name}{$id}{$value}{$size}{$format} />";
+			$options = isset($field['js']) ? " data-options='" . json_encode($field['js']) . "'" : "";
+			$html .= "<input type='text' class='rwmb-datetime'{$name}{$id}{$value}{$size}{$format}{$options} />";
 
 			return $html;
 		}

--- a/js/date.js
+++ b/js/date.js
@@ -9,12 +9,22 @@ function rwmb_update_date_picker()
 	$( '.rwmb-date' ).each( function()
 	{
 		var $this = $( this ),
-			format = $this.attr( 'rel' );
+			picker,
+			format = $this.attr( 'rel' ),
+			custom = $this.attr( 'data-options' );
 
-		$this.removeClass('hasDatepicker').attr('id', '').datepicker( {
+		picker = $this.removeClass('hasDatepicker').attr('id', '').datepicker( {
 			showButtonPanel: true,
 			dateFormat:	     format
 		} );
+
+		if ( typeof(custom) != 'undefined' ) {
+			custom = JSON.parse(custom);  
+				for (var key in custom) {
+					picker.datepicker( "option" , key , custom[key] ); 
+			}
+		}
+
 	} );
 }
 

--- a/js/datetime.js
+++ b/js/datetime.js
@@ -9,17 +9,27 @@ function rwmb_update_datetime_picker()
 	$( '.rwmb-datetime' ).each( function()
 	{
 		var $this = $( this ),
+			picker,
 			format = $this.attr( 'rel' ),
+			custom = $this.attr( 'data-options' ),
 			show_amppm = /t/i.test(format),
 			show_second = /:s/.test(format),
 			show_millisec = /:l/.test(format);
 
-		$this.removeClass('hasDatepicker').attr('id', '').datetimepicker( {
+		picker = $this.removeClass('hasDatepicker').attr('id', '').datetimepicker( {
 			showSecond  : show_second,
 			showMillisec: show_millisec,
 			timeFormat  : format,
 			ampm        : show_amppm,
 		} );
+
+		if ( typeof(custom) != 'undefined' ) {
+			custom = JSON.parse(custom);  
+				for (var key in custom) {
+					picker.datepicker( "option" , key , custom[key] ); 
+			}
+		}
+
 	} );
 }
 


### PR DESCRIPTION
attempt to pass custom JS options to datepicker per issue #160

custom options would be defined like so:

```
'fields' => array(
        // START TTIME
        array(
            'name' => 'Start Time',
            'id'   => "{$prefix}start_time",
            'type' => 'datetime',
            // Time format, default yy-mm-dd hh:mm. Optional. @link See: http://goo.gl/hXHWz
            'format' => 'h:mm tt',
            'description' => 'Format M d, YYYY HH:MM',
            'js' => array ( 'dateFormat' => 'M d, yy',
                            'stepMinute' => 5 )
        ),
```

This is working with the jquery ui date picker using their [option method](http://jqueryui.com/demos/datepicker/#methods).  However, I can't figure out how to do the same thing with the datetime addon-specific options... so datetime picker specific options like `stepMinute` don't do anything yet.
