### PR TITLE
Add size option to select and select-advanced field types.

### DIFF
--- a/inc/fields/select-advanced.php
+++ b/inc/fields/select-advanced.php
@@ -33,11 +33,12 @@ if ( !class_exists( 'RWMB_Select_Advanced_Field' ) )
 		 * @return string
 		 */
 		static function html( $html, $meta, $field )
-		{			
+		{
 			$html = sprintf(
-				'<select class="rwmb-select-advanced" name="%s" id="%s"%s data-options="%s">',
+				'<select class="rwmb-select-advanced" name="%s" id="%s" size="%s"%s data-options="%s">',
 				$field['field_name'],
 				$field['id'],
+				$field['size'],
 				$field['multiple'] ? ' multiple="multiple"' : '',
 				esc_attr( json_encode( $field['js_options'] ) )
 			);
@@ -70,9 +71,10 @@ if ( !class_exists( 'RWMB_Select_Advanced_Field' ) )
 		static function normalize_field( $field )
 		{
 			$field = parent::normalize_field( $field );
-	
-			
+
+
 			$field = wp_parse_args( $field, array(
+				'size' => $field['multiple'] ? 5 : 0,
 				'js_options' => array(),
 			) );
 

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -28,9 +28,10 @@ if ( !class_exists( 'RWMB_Select_Field' ) )
 		static function html( $html, $meta, $field )
 		{
 			$html = sprintf(
-				'<select class="rwmb-select" name="%s" id="%s"%s>',
+				'<select class="rwmb-select" name="%s" id="%s" size="%s"%s>',
 				$field['field_name'],
 				$field['id'],
+				$field['size'],
 				$field['multiple'] ? ' multiple="multiple"' : ''
 			);
 			$option = '<option value="%s" %s>%s</option>';
@@ -112,6 +113,9 @@ if ( !class_exists( 'RWMB_Select_Field' ) )
 		 */
 		static function normalize_field( $field )
 		{
+			$field = wp_parse_args( $field, array(
+				'size' => $field['multiple'] ? 5 : 0
+			) );
 			$field['field_name'] = $field['id'];
 			if ( !$field['clone'] && $field['multiple'] )
 				$field['field_name'] .= '[]';


### PR DESCRIPTION
Default to five items for multi-selects, and 0 for single-selects. According to https://developer.mozilla.org/en-US/docs/HTML/Element/select the default size for single-selects should be 0 and not 1.
