### PR TITLE
Fixing the map geolocation when having a list of text fields as address_field

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,4 +1,3 @@
-
 var marker, map, geocoder;
 
 jQuery( document ).ready( function ()
@@ -65,6 +64,7 @@ jQuery( document ).ready( function ()
       for ( loop = 0; loop < fieldList.length; loop++ )
       {
          address += jQuery( '#' + fieldList[loop] ).val();
+         if(loop+1 < fieldList.length) {  address += ', '; }
       }
 
       address = address.replace( /\n/g, ',' );


### PR DESCRIPTION
Hi, I was facing an issue trying to have more than one text field as "address_field" array value for a map meta box, for example:
                array(
                'id'            => 'loc',
                'name'          => 'Location',
                'type'          => 'map',
                'std'           => '-6.233406,-35.049906,15',
                'style'         => 'width: 500px; height: 500px',
                'address_field' => 'street_address,postal_code,city,country',

The address sent to google maps was missing a separator between the text fields values.
Also no spaces should be used between the field names, it would generate an error.
I hope this helps.

Thanks a lot for your work!
