### PR TITLE
normalize_field safe for 'post_type' => array(...)

### DIFF
--- a/inc/fields/posts.php
+++ b/inc/fields/posts.php
@@ -49,12 +49,17 @@ if ( !class_exists( 'RWMB_Posts_Field' ) )
 		 * @return array
 		 */
 		static function normalize_field( $field )
-		{		
-			$pt_obj = get_post_type_object( $field['post_type'] );	
+		{
+			$default_post_type = "Post";
+			if(is_string($field['post_type'])) {
+			  $pt_obj = get_post_type_object( $field['post_type'] );	
+                          $default_post_type = $pt_obj->labels->singular_name;
+                        }
+
 			$field = wp_parse_args( $field, array(
 				'post_type' => 'post',
 				'field_type' => 'select_advanced',
-				'default'    =>  sprintf( __( 'Select a %s' , 'rwmb' ), $pt_obj->labels->singular_name ), 
+				'default'    =>  sprintf( __( 'Select a %s' , 'rwmb' ), $default_post_type ), 
 				'parent' => false,
 				'query_args' => array()
 			) );


### PR DESCRIPTION
Adding a default string for complex types, using the "singular_name" only if it's a single post type.  This will correct a small error when an array is used for post_type.
