### PR TITLE
Fixes #287

### DIFF
--- a/inc/classes/meta-box.php
+++ b/inc/classes/meta-box.php
@@ -445,7 +445,7 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 				$new  = isset( $_POST[$name] ) ? $_POST[$name] : ( $field['multiple'] ? array() : '' );
 
 				// Stops images from being removed as per issue #287
-				if((!isset($old) || empty($old)) && (!isset($new) || empty($new))) {
+				if(empty($old) && empty($new)) {
 					continue;
 				}
 


### PR DESCRIPTION
By skipping the save logic when both the new value and the old value are blank, we stop wasting time doing the persistence logic for a change which does nothing and we also avoid triggering the bug where images sometimes get unset.
