### PR TITLE
Create new field for multi line text inputs

### DIFF
--- a/inc/fields/fieldset-text.php
+++ b/inc/fields/fieldset-text.php
@@ -1,0 +1,83 @@
+<?php
+// Prevent loading this file directly
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'RWMB_Fieldset_Text_Field' ) )
+{
+  class RWMB_Fieldset_Text_Field
+  {
+    /**
+     * Get field HTML
+     *
+     * @param string $html
+     * @param mixed  $meta
+     * @param array  $field
+     *
+     * @return string
+     */
+    static function html( $html, $meta, $field )
+    {
+      $out = '';
+
+      if (count($meta)==1 && trim($meta[0])=='') {
+        $meta = "";
+      }
+
+      $html = array();
+      $before = '<fieldset><legend>'.$field['desc'].'</legend>';
+      $after   = '</fieldset>';
+      
+      $tpl = '<label>%s <input type="text" class="rwmb-fieldset-text" name="%s[%s][%d]" placeholder="%s" value="%s" /></label>';
+      
+      for($n=0;$n<$field['rows'];$n++) {
+        foreach( $field['options'] as $k => $v ) {
+          $fid = $field['id'];
+          if (is_array($meta) && !empty($meta)) {
+            $html[] = sprintf($tpl, $k, $fid, $v, $n, $k, $meta[$v][$n]);
+          } else {
+            $html[] = sprintf($tpl, $k, $fid, $v, $n, $k, '');
+          }
+        }
+        $html[] = "<br/>\n";
+      }
+
+      $out = $before . implode( ' ', $html ) . $after;
+      return $out;
+    }
+
+    /**
+     * Get meta value
+     *
+     * @param $meta
+     * @param $post_id
+     * @param $saved
+     * @param $field
+     *
+     * @return array
+     */
+    static function meta( $meta, $post_id, $saved, $field )
+    {
+      $meta = get_post_meta( $post_id, $field['id'] );
+
+      if (is_array($meta) && !empty($meta)) {
+        $meta = $meta[0];
+      }
+
+      return $meta;
+    }
+
+    /**
+     * Save meta value
+     *
+     * @param $new
+     * @param $old
+     * @param $post_id
+     * @param $field
+     */
+    static function save( $new, $old, $post_id, $field )
+    {
+      update_post_meta($post_id, $field['id'], $new, $old);
+    }
+
+  }
+}


### PR DESCRIPTION
I've created a reliable way of adding lists of textboxes.
In the field options, specifying the rows will create that many lines.
Then the options array is defined as Label => field and as many fields per line you need.

e.g.

``` php
$meta_boxes[] = array(
    'id'    => 'top10_metabox',
    'title' => 'Favourite Tunes',
    'pages' => 'some pages',

    'fields' => array(
      array(
        'name' => 'Top Tracks',
        'id'   => $prefix . 'toptrack',
        'desc' => 'Your Top Tunes go here.',
        'type' => 'fieldset_text',
        'rows' => 10,

        'options' => array(
          'Artist' => 'artist',
          'Track'  => 'track',
          'Link'   => 'link',
        ),
      ),
    ),
  );
```
