### PR TITLE
Fixing taxonomy/checkbox-list bug - could not clear out all selected taxonomies

### DIFF
--- a/inc/classes/meta-box.php
+++ b/inc/classes/meta-box.php
@@ -520,7 +520,7 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 				$new = apply_filters( "rwmb_{$name}_value", $new, $field, $old );
 
 				// Stops images from being removed as per issue #287
-				if ( empty( $old ) && empty( $new ) )
+				if ( empty( $old ) && empty( $new ) && $field['type'] != 'taxonomy' )
 					continue;
 
 				// Call defined method to save meta value, if there's no methods, call common one


### PR DESCRIPTION
Using a taxonomy field type with checkbox-list, I was unable to clear all selected taxonomy terms.  The taxonomy field type should be omitted from this if statement to avoid this.  Seeing as the if statement was inserted to fix a specific image clearing issue, it may be better to check for specific fieldtypes here instead of omitting taxonomy.
