### PR TITLE
allow specifying default position for map fields

### DIFF
--- a/inc/fields/map.php
+++ b/inc/fields/map.php
@@ -36,7 +36,7 @@ if ( !class_exists( 'RWMB_Map_Field' ) )
 				'<div class="rwmb-map-canvas" style="%s"%s></div>
 				<input type="hidden" name="%s" class="rwmb-map-coordinate" value="%s">',
 				isset( $field['style'] ) ? $field['style'] : '',
-				isset( $field['default_loc'] ) ? " data-default-lat=\"{$field['default_loc'][0]}\" data-default-lng=\"{$field['default_loc'][1]}\"" : '',
+				isset( $field['std'] ) ? " data-default-loc=\"{$field['std']}\"" : '',
 				$field['field_name'],
 				$meta
 			);

--- a/js/map.js
+++ b/js/map.js
@@ -33,7 +33,16 @@
 		// Initialize map elements
 		initMapElements: function()
 		{
-			var latLng = new google.maps.LatLng( $(this.canvas).data('default-lat') || 53.346881, $(this.canvas).data('default-lng') || -6.258860 ); // Initial position for map
+			var defaultLoc = $(this.canvas).data('default-loc'),
+				latLng;
+
+			if (defaultLoc) {
+				defaultLoc = defaultLoc.split(',');
+			} else {
+				defaultLoc = [53.346881, -6.258860];
+			}
+
+			latLng = new google.maps.LatLng( defaultLoc[0], defaultLoc[1] ); // Initial position for map
 
 	 		this.map = new google.maps.Map( this.canvas, {
 				center: latLng,


### PR DESCRIPTION
Adds a 'default_loc' configuration parameter for these field types. The value should be a two-element array containing latitude & longitude (in that order) as decimal degrees.
