### PR TITLE
Fixing WP oembed error with changing wp_oembed_get()

### DIFF
--- a/inc/fields/oembed.php
+++ b/inc/fields/oembed.php
@@ -57,8 +57,10 @@ if ( ! class_exists( 'RWMB_OEmbed_Field' ) )
 
 		static function get_embed( $url )
 		{
-				
-			$embed = wp_oembed_get( esc_url( $url ) );
+			global $wp_embed;
+			
+			$embed = $wp_embed->run_shortcode('[embed]'.esc_url( $url ).'[/embed]');
+			// $embed = wp_oembed_get( esc_url( $url ) );
 
 			if( $embed )
 			{


### PR DESCRIPTION
Just activate this plugin and got an error

![2013-10-06 02_15_06-add new gallery in-tri-cate wordpress](https://f.cloud.github.com/assets/508665/1275339/a9b196d0-2df3-11e3-80b8-95052d0d308b.png)

Try to find some solutions and stick with [this one](http://stackoverflow.com/questions/18041225/strict-standards-only-variables-should-be-passed-by-reference-in-wordpress-wp-i)
