### PR TITLE
Avoid fatal error on PHP 5.2

### DIFF
--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -688,7 +688,8 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 		 */
 		static function do_field_actions( $field, $method )
 		{
-			call_user_func_array( array( __CLASS__, 'apply_field_filters' ), func_get_args() );
+			$args = func_get_args();
+			call_user_func_array( array( __CLASS__, 'apply_field_filters' ), $args );
 		}
 
 		/**


### PR DESCRIPTION
Passing func_get_args() directly to call_user_func_array() causes a fatal error in PHP 5.2, which is fixed by first putting the results in a variable.
