### PR TITLE
if no maxFuleUploads defined the dropArea don't have to be hidden

### DIFF
--- a/js/plupload-image.js
+++ b/js/plupload-image.js
@@ -53,7 +53,7 @@ jQuery( function( $ )
 			}
 
 			// Hide drag & drop section if reach max file uploads
-			if ( uploaded + files.length >= maxFileUploads )
+			if ( maxFileUploads > 0 && uploaded + files.length >= maxFileUploads )
 				$dropArea.addClass( 'hidden' );
 
 			max = parseInt( up.settings.max_file_size, 10 );


### PR DESCRIPTION
Its either this or you have to make sure it will show up again AFTER
everr file is uploaded.
Also when you upload 8 files and 6 fail, scripts still counts 8 to
determine to hide or show dropArea.
