### PR TITLE
Added "category" in better include demo

### DIFF
--- a/demo/better-include.php
+++ b/demo/better-include.php
@@ -105,6 +105,16 @@ function rw_maybe_include( $conditions ) {
 					return true;
 				}
 			break;
+			case 'category': //post must be saved or published first
+				$categories = get_the_category( $post->ID );
+				$catslugs = array();
+				foreach ($categories as $category) {
+					array_push($catslugs, $category->slug);
+				}
+				if ( array_intersect( $catslugs, $v ) ) {
+					return true;
+				}
+			break;
 			case 'template':
 				$template = get_post_meta( $post_id, '_wp_page_template', true );
 				if ( in_array( $template, $v ) ) {


### PR DESCRIPTION
added a new case 'category' in the demo in case someone's looking for a way to show specific meta-box based on category-slug. the caveat is that the post must have an assigned category and  saved or published first before the script can take effect
