### PR TITLE
Update image-advanced.php

### DIFF
--- a/inc/fields/image-advanced.php
+++ b/inc/fields/image-advanced.php
@@ -116,7 +116,7 @@ if ( ! class_exists( 'RWMB_Image_Advanced_Field' ) )
 					<# } #>
 					<div class="rwmb-image-bar">
 						<a title="<?php echo $i18n_edit; ?>" class="rwmb-edit-file" href="{{{ attachment.editLink }}}" target="_blank"><?php echo $i18n_edit; ?></a> |
-						<a title="<?php echo $i18n_delete; ?>" class="rwmb-delete-file" href="#" data-attachment_id="{{{ attachment.id }}}">×</a>
+						<a title="<?php echo $i18n_delete; ?>" class="rwmb-delete-file" href="#" data-attachment_id="{{{ attachment.id }}}">&times;</a>
 					</div>
 				</li>
 				<# } ); #>


### PR DESCRIPTION
Theme Check Error. Fix for Non-printable characters were found in the image-advanced.php file.
