### PR TITLE
Launch geolocation autocomplete when address field is cloned

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -62,6 +62,11 @@ if ( !class_exists( 'RWMB_Field ' ) )
 				{
 					$sub_field = $field;
 					$sub_field['field_name'] = $field['field_name'] . "[{$index}]";
+					if ($index>0) {
+						if (isset( $sub_field['address_field'] )) 
+							$sub_field['address_field'] = $field['address_field'] . "_{$index}";
+						$sub_field['id'] = $field['id'] . "_{$index}";
+					}
 					if ( $field['multiple'] )
 						$sub_field['field_name'] .= '[]';
 

--- a/js/clone.js
+++ b/js/clone.js
@@ -6,10 +6,11 @@ jQuery( document ).ready( function( $ )
 	{
 		var $clone_last = $input.find( '.rwmb-clone:last' ),
 			$clone = $clone_last.clone(),
-			$input, name;
+			$input, $address_button, name, id;
 	
 		$clone.insertAfter( $clone_last );
 		$input = $clone.find( ':input[class|="rwmb"]' );
+		$address_button = $clone.find( '.rwmb-map-goto-address-button' );
 
 		// Reset value
 		$input.val( '' );
@@ -22,6 +23,33 @@ jQuery( document ).ready( function( $ )
 
 		// Update the "name" attribute
 		$input.attr( 'name', name );
+
+		// Get the field id, and increment
+		var pattern = new RegExp(/_(\d+)/);
+		if (pattern.test($input.attr( 'id' ))) {
+			id = $input.attr( 'id' ).replace( /_(\d+)/, function( match, p1 )
+			{
+				return '_' + ( parseInt( p1 ) + 1 ) ;
+			} );
+		} else {
+			id = $input.attr( 'id' ) + '_1';
+		}
+
+		// Update the "id" attribute
+		$input.attr( 'id', id );
+
+		// Update the address_button "value" attribute
+		if($address_button) {
+			if (pattern.test($address_button.attr( 'value' ))) {
+				id = $address_button.attr( 'value' ).replace( /_(\d+)/, function( match, p1 )
+				{
+					return '_' + ( parseInt( p1 ) + 1 ) ;
+				} );
+			} else {
+				id = $address_button.attr( 'value' ) + '_1';
+			}
+			$address_button.attr( 'value', id );
+		}
 
 		// Toggle remove buttons
 		toggle_remove_buttons( $input );

--- a/js/map.js
+++ b/js/map.js
@@ -182,6 +182,16 @@
 
 			$( this ).data('mapController', field);
 		} );
+
+		$( '.rwmb-input' ).on( 'clone', function(params){
+			$( '.rwmb-map-field' ).each( function()
+			{
+				var field = new mapField( $( this ) );
+				field.init();
+
+				$( this ).data('mapController', field);
+			});
+		});
 	} );
 
 } )( jQuery );


### PR DESCRIPTION
When a field used as address_field is cloned, the autocomplete is started.
For the moment it need to also clone the map field and clone-group must be defined for both fields.
Could be better to only clone the coordinate field and add marker on the same map.
