### PR TITLE
Remove 'meta' function from RWMB_Image_Field Class

### DIFF
--- a/inc/fields/image.php
+++ b/inc/fields/image.php
@@ -158,26 +158,5 @@ if ( ! class_exists( 'RWMB_Image_Field' ) )
 			);
 		}
 
-		/**
-		 * Standard meta retrieval
-		 *
-		 * @param int   $post_id
-		 * @param array $field
-		 * @param bool  $saved
-		 *
-		 * @return mixed
-		 */
-		static function meta( $post_id, $saved, $field )
-		{
-			global $wpdb;
-
-			$meta = $wpdb->get_col( $wpdb->prepare( "
-				SELECT meta_value FROM $wpdb->postmeta
-				WHERE post_id = %d AND meta_key = '%s'
-				ORDER BY meta_id ASC
-			", $post_id, $field['id'] ) );
-
-			return empty( $meta ) ? array() : $meta;
-		}
 	}
 }


### PR DESCRIPTION
This allow us to use the "std" parameter and the "rwmb_*_meta" filters.

I don't think this function was useful anymore ?
