### PR TITLE
Allow multiple fields to be incremented properly

### DIFF
--- a/js/clone.js
+++ b/js/clone.js
@@ -14,14 +14,6 @@ jQuery( document ).ready( function( $ )
 		
 		// Increment each field type
 		$input.each(function() {
-			if ( $(this).attr('type') == 'radio' || $(this).attr('type') == 'checkbox' ) {
-				// Reset 'checked' attribute
-				$(this).removeAttr('checked');
-			} else {
-				// Reset value
-				$(this).val( '' );
-			}
-			
 			// Preserve previous checked value
 			if ( $(this).attr('type') == 'radio' ) {
 				var $radio_name = $(this).attr('name'), 
@@ -29,6 +21,14 @@ jQuery( document ).ready( function( $ )
 			
 				if ( $(this).is(':checked') )
 					$radio_value = $(this).val();
+			}
+			
+			if ( $(this).attr('type') == 'radio' || $(this).attr('type') == 'checkbox' ) {
+				// Reset 'checked' attribute
+				$(this).removeAttr('checked');
+			} else {
+				// Reset value
+				$(this).val( '' );
 			}
 			
 			// Get the field name, and increment


### PR DESCRIPTION
I've wrapped the $input in an each loop to capture all the fields that would be cloned and this would make way to multiple fields being cloned properly in terms of name and id field.

Initially, the current javascript code treats multiple fields to have the same input name and id.

So if there is this fields:

<pre>
&lt;input type="text" name="field[0][url]" value="" /&gt;
&lt;input type="text" name="field[0][name]" value="" /&gt;
</pre>


If cloned, it would end up like this:

<pre>
&lt;input type="text" name="field[1][url]" value="" /&gt;
&lt;nput type="text" name="field[1][url]" value="" /&gt;
</pre>


The above proposed fix will fix this issue.
