### PR TITLE
Add wordpress-plugin tag for composer installers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "ui",
     "select2",
     "wp-admin",
-    "meta-box"
+    "meta-box",
+    "wordpress-plugin"
   ],
   "version": "4.3.8",
   "description": "Easily create custom meta boxes in WordPress.",


### PR DESCRIPTION
Add custom tag `wordpress-plugin` for use with composer installers.

See: https://github.com/composer/installers#current-supported-types
