### PR TITLE
jQuery UI Datepicker/Timepicker locale files...

### DIFF
--- a/inc/fields/date.php
+++ b/inc/fields/date.php
@@ -20,12 +20,18 @@ if ( ! class_exists( 'RWMB_Date_Field' ) )
 
 			// Load localized scripts
 			$locale = str_replace( '_', '-', get_locale() );
-			$file_path = 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . $locale . '.js';
+			$file_paths = array( 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . $locale . '.js' );
+			// Also check alternate i18n filename (e.g. jquery.ui.datepicker-de.js instead of jquery.ui.datepicker-de-DE.js)
+			if ( strlen( $locale ) > 2 ) $file_paths[] = 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . substr( $locale, 0, 2 ) . '.js';
 			$deps = array( 'jquery-ui-datepicker' );
-			if ( file_exists( RWMB_DIR . 'js/' . $file_path ) )
+			foreach ( $file_paths as $file_path )
 			{
-				wp_register_script( 'jquery-ui-datepicker-i18n', RWMB_JS_URL . $file_path, $deps, '1.8.17', true );
-				$deps[] = 'jquery-ui-datepicker-i18n';
+				if ( file_exists( RWMB_DIR . 'js/' . $file_path ) )
+				{
+					wp_register_script( 'jquery-ui-datepicker-i18n', RWMB_JS_URL . $file_path, $deps, '1.8.17', true );
+					$deps[] = 'jquery-ui-datepicker-i18n';
+					break;
+				}
 			}
 
 			wp_enqueue_script( 'rwmb-date', RWMB_JS_URL . 'date.js', $deps, RWMB_VER, true );

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -24,18 +24,32 @@ if ( ! class_exists( 'RWMB_Datetime_Field' ) )
 
 			// Load localized scripts
 			$locale = str_replace( '_', '-', get_locale() );
-			$date_path = 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . $locale . '.js';
-			$time_path = 'jqueryui/timepicker-i18n/jquery-ui-timepicker-' . $locale . '.js';
-			$deps = array( 'jquery-ui-datepicker', 'jquery-ui-timepicker' );
-			if ( file_exists( RWMB_DIR . 'js/' . $date_path ) )
-			{
-				wp_register_script( 'jquery-ui-datepicker-i18n', RWMB_JS_URL . $date_path, array( 'jquery-ui-datepicker' ), '1.8.17', true );
-				$deps[] = 'jquery-ui-datepicker-i18n';
+			$date_paths = array( 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . $locale . '.js' );
+			$time_paths = array( 'jqueryui/timepicker-i18n/jquery-ui-timepicker-' . $locale . '.js' );
+			if ( strlen( $locale ) > 2 ) {
+				// Also check alternate i18n filenames
+				// (e.g. jquery.ui.datepicker-de.js instead of jquery.ui.datepicker-de-DE.js)
+				$date_paths[] = 'jqueryui/datepicker-i18n/jquery.ui.datepicker-' . substr( $locale, 0, 2 ) . '.js';
+				$time_paths[] = 'jqueryui/timepicker-i18n/jquery-ui-timepicker-' . substr( $locale, 0, 2 ) . '.js';
 			}
-			if ( file_exists( RWMB_DIR . 'js/' . $time_path ) )
+			$deps = array( 'jquery-ui-datepicker', 'jquery-ui-timepicker' );
+			foreach ( $date_paths as $date_path )
 			{
-				wp_register_script( 'jquery-ui-timepicker-i18n', RWMB_JS_URL . $time_path, array( 'jquery-ui-timepicker' ), '1.8.17', true );
-				$deps[] = 'jquery-ui-timepicker-i18n';
+				if ( file_exists( RWMB_DIR . 'js/' . $date_path ) )
+				{
+					wp_register_script( 'jquery-ui-datepicker-i18n', RWMB_JS_URL . $date_path, array( 'jquery-ui-datepicker' ), '1.8.17', true );
+					$deps[] = 'jquery-ui-datepicker-i18n';
+					break;
+				}
+			}
+			foreach ( $time_paths as $time_path )
+			{
+				if ( file_exists( RWMB_DIR . 'js/' . $time_path ) )
+				{
+					wp_register_script( 'jquery-ui-timepicker-i18n', RWMB_JS_URL . $time_path, array( 'jquery-ui-timepicker' ), '1.8.17', true );
+					$deps[] = 'jquery-ui-timepicker-i18n';
+					break;
+				}
 			}
 
 			wp_enqueue_script( 'rwmb-datetime', RWMB_JS_URL . 'datetime.js', $deps, RWMB_VER, true );

--- a/inc/fields/time.php
+++ b/inc/fields/time.php
@@ -22,11 +22,24 @@ if ( ! class_exists( 'RWMB_Time_Field' ) )
 
 			$url = RWMB_JS_URL . 'jqueryui';
 			wp_register_script( 'jquery-ui-timepicker', "{$url}/jquery-ui-timepicker-addon.js", array( 'jquery-ui-datepicker', 'jquery-ui-slider' ), '0.9.7', true );
+			$deps = array( 'jquery-ui-timepicker' );
 
 			$locale = str_replace( '_', '-', get_locale() );
-			wp_register_script( 'jquery-ui-timepicker-i18n', "{$url}/timepicker-i18n/jquery-ui-timepicker-{$locale}.js", array( 'jquery-ui-timepicker' ), '0.9.7', true );
+			if ( file_exists( RWMB_DIR . "js/jqueryui/timepicker-i18n/jquery-ui-timepicker-{$locale}.js" ) )
+			{
+				$timepicker_locale_js_url = "{$url}/timepicker-i18n/jquery-ui-timepicker-{$locale}.js";
+			}
+			elseif ( strlen( $locale ) > 2 && file_exists( RWMB_DIR . 'js/jqueryui/timepicker-i18n/jquery-ui-timepicker-' . substr( $locale, 0, 2 ) . '.js' ) )
+			{
+				$timepicker_locale_js_url = "{$url}/timepicker-i18n/jquery-ui-timepicker-" . substr( $locale, 0, 2 ) . '.js';
+			}
+			if ( $timepicker_locale_js_url )
+			{
+				wp_register_script( 'jquery-ui-timepicker-i18n', $timepicker_locale_js_url, array( 'jquery-ui-timepicker' ), '0.9.7', true );
+				$deps = array( 'jquery-ui-timepicker-i18n' );
+			}
 
-			wp_enqueue_script( 'rwmb-time', RWMB_JS_URL.'time.js', array( 'jquery-ui-timepicker' ), RWMB_VER, true );
+			wp_enqueue_script( 'rwmb-time', RWMB_JS_URL.'time.js', $deps, RWMB_VER, true );
 			wp_localize_script( 'rwmb-time', 'RWMB_Timepicker', array( 'lang' => $locale ) );
 		}
 


### PR DESCRIPTION
...aren't being loaded if the WP locale definition doesn't match the corresponding value in the filename (e.g. "de-DE" vs. "de"). Checking the alternate filename variants (e.g. jquery-jquery-ui-timepicker-de.js instead of ui-timepicker-de-DE.js) did the trick for me.
