### PR TITLE
Added ability to target page/post based on id

### DIFF
--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -104,6 +104,15 @@ if ( ! class_exists( 'RW_Meta_Box' ) )
 		{
 			$screen = get_current_screen();
 
+            foreach ( $this->meta_box['pages'] as $key => $page ) {
+                if ( is_array( $page ) ) {
+                    if ( isset( $page['page'] ) ) {
+                        $this->meta_box['pages'][] = $page['page'];
+                    }
+                    unset( $this->meta_box['pages'][ $key ] );
+                }
+            }
+
 			// Enqueue scripts and styles for registered pages (post types) only
 			if ( 'post' != $screen->base || ! in_array( $screen->post_type, $this->meta_box['pages'] ) )
 				return;


### PR DESCRIPTION
Allows you to add a metabox on a single page by checking the id. The setup array would change from `'page' => 'page'` to `'page' => array('id' => 23, 'page' => 'post')` just for targeting the id. Everything else would remain the same.
