### PR TITLE
Fixing a mistake related to l10n

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'RWMB_Common' ) )
 			$mofile = "{$dir}{$locale}.mo";
 
 			// In themes/plugins/mu-plugins directory
-			load_textdomain( 'rwmb', $mofile );
+			load_textdomain( 'meta-box', $mofile );
 		}
 
 		/**


### PR DESCRIPTION
I noticed the localization files weren't working and i noticed that you use 'meta-box' everywhere, while the load_textdomain is loading the $mofile as "rwmb".

I did a test here and now it works just fine. I also updated the brazilian portuguese .po .mo files, if you are interested.
