### PR TITLE
Fixed bug that keeps new cloned fields hidden

### DIFF
--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -5,9 +5,12 @@ jQuery( function ( $ )
 	function rwmb_update_select_advanced()
 	{
 		var $this = $( this ),
-			options = $this.data( 'options' );
+			options = $this.data( 'options' ),
+			width = $this.siblings( '.select2-container' ).width();
 		$this.siblings( '.select2-container' ).remove();
+		$this.removeAttr('style');
 		$this.select2( options );
+		$this.siblings( '.select2-container' ).width(width);
 	}
 
 	$( ':input.rwmb-select-advanced' ).each( rwmb_update_select_advanced );


### PR DESCRIPTION
This commit fixes a bug that exists when trying to add a new cloned select2 dropdown. The element stored in `$this` had `style="display: none;` added to it when it was originally "selectized" on instantiation, after clone this attribute was being retained thus hiding the new select2 container. The width of the cloned select2 container was also off so I also added code to mimic the existing select2s.
