### PR TITLE
Fixed broken HTML markup

### DIFF
--- a/inc/fields/heading.php
+++ b/inc/fields/heading.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'RWMB_Heading_Field' ) )
 		 */
 		static function end_html( $meta, $field )
 		{
-			$id = $field['id'] ? " id='{$field['id']}-description" : '';
+			$id = $field['id'] ? " id='{$field['id']}-description'" : '';
 
 			return $field['desc'] ? "<p{$id} class='description'>{$field['desc']}</p>" : '';
 		}


### PR DESCRIPTION
the id attribute was missing the closing quote, breaking the rest of the element.
