### PR TITLE
Update date field to allow empty string input

### DIFF
--- a/js/date.js
+++ b/js/date.js
@@ -23,6 +23,10 @@ jQuery( function ( $ ) {
 		if ( $inline.length ) {
 			options.altField = '#' + $this.attr( 'id' );
 			$this.on( 'keydown', _.debounce( function () {
+				// if val is empty, return to allow empty datepicker input.
+				if ( !$this.val() ) {
+					return;
+				}
 				$picker
 					.datepicker( 'setDate', $this.val() )
 					.find( ".ui-datepicker-current-day" )


### PR DESCRIPTION
I found a bug where if an inline calendar is being used, and the user tries to clear the date input field when there is already an entered date, the field would auto-fill to today's date.

Could you possibly include this in the next plugin update release?

Thanks!