### PR TITLE
added filter for $field

### DIFF
--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -294,6 +294,8 @@ class RW_Meta_Box {
 				$new = RWMB_Field::filter( 'sanitize', $new, $field );
 			}
 			$new = RWMB_Field::filter( 'value', $new, $field, $old );
+			// Filter to allow the field to be modified
+			$field = RWMB_Field::filter( 'field', $new, $field, $old );
 
 			// Call defined method to save meta value, if there's no methods, call common one.
 			RWMB_Field::call( $field, 'save', $new, $old, $post_id );

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -294,7 +294,7 @@ class RW_Meta_Box {
 				$new = RWMB_Field::filter( 'sanitize', $new, $field );
 			}
 			$new = RWMB_Field::filter( 'value', $new, $field, $old );
-			// Filter to allow the field to be modified
+			// Filter to allow the field to be modified.
 			$field = RWMB_Field::filter( 'field', $new, $field, $old );
 
 			// Call defined method to save meta value, if there's no methods, call common one.


### PR DESCRIPTION
added field filter to allow the $field object to be modified before saving meta. Useful if a user does not have rights to make changes, but can submit changes for review.