### PR TITLE
Optimize object fields (post, user, taxonomy)

### DIFF
--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -7,9 +7,11 @@
     <description>A custom set of code standard rules to check for Meta Box plugin.</description>
 
     <!-- Include the WordPress ruleset, with exclusions. -->
-    <rule ref="WordPress">
+    <rule ref="WordPress-Core"/>
         <exclude name="WordPress.Files.FileName" />
     </rule>
+    <rule ref="WordPress-Docs"/></rule>
+    <rule ref="WordPress-Extra"/></rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
     <config name="testVersion" value="5.2-99.0"/>

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -8,7 +8,7 @@
 
     <!-- Include the WordPress ruleset, with exclusions. -->
     <rule ref="WordPress-Docs" />
-    <rule ref="WordPress-Extra"/>
+    <rule ref="WordPress-Extra">
         <exclude name="WordPress.Files.FileName" />
     </rule>
 

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -7,11 +7,10 @@
     <description>A custom set of code standard rules to check for Meta Box plugin.</description>
 
     <!-- Include the WordPress ruleset, with exclusions. -->
-    <rule ref="WordPress-Core"/>
+    <rule ref="WordPress-Docs" />
+    <rule ref="WordPress-Extra"/>
         <exclude name="WordPress.Files.FileName" />
     </rule>
-    <rule ref="WordPress-Docs"/></rule>
-    <rule ref="WordPress-Extra"/></rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
     <config name="testVersion" value="5.2-99.0"/>

--- a/inc/fields/button-group.php
+++ b/inc/fields/button-group.php
@@ -20,15 +20,14 @@ class RWMB_Button_Group_Field extends RWMB_Choice_Field {
 	/**
 	 * Walk options.
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 *
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
-		$walker = new RWMB_Walker_Input_List( $db_fields, $field, $meta );
+	public static function walk( $field, $options, $meta ) {
+		$walker = new RWMB_Walker_Input_List( $field, $meta );
 
 		$output = sprintf( '<ul class="rwmb-button-input-list %s">',
 			$field['inline'] ? 'inline' : ''

--- a/inc/fields/button-group.php
+++ b/inc/fields/button-group.php
@@ -18,21 +18,19 @@ class RWMB_Button_Group_Field extends RWMB_Choice_Field {
 	}
 
 	/**
-	 * Walk options.
+	 * Get field HTML.
 	 *
-	 * @param array $field   Field parameters.
-	 * @param mixed $options Field options.
-	 * @param mixed $meta    Meta value.
-	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $meta ) {
+	public static function html( $meta, $field ) {
 		$walker = new RWMB_Walker_Input_List( $field, $meta );
 
 		$output = sprintf( '<ul class="rwmb-button-input-list %s">',
 			$field['inline'] ? 'inline' : ''
 		);
-		$output .= $walker->walk( $options, - 1 );
+		$output .= $walker->walk( $field['options_transformed'], -1 );
 		$output .= '</ul>';
 
 		return $output;

--- a/inc/fields/choice.php
+++ b/inc/fields/choice.php
@@ -83,18 +83,6 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	 * @return string
 	 */
 	public static function format_single_value( $field, $value, $args, $post_id ) {
-		return self::call( 'get_option_label', $field, $value );
-	}
-
-	/**
-	 * Get option label.
-	 *
-	 * @param array  $field Field parameters.
-	 * @param string $value Option value.
-	 *
-	 * @return string
-	 */
-	public static function get_option_label( $field, $value ) {
 		$options = $field['options_transformed'];
 		return isset( $options[ $value ] ) ? $options[ $value ]->label : '';
 	}

--- a/inc/fields/choice.php
+++ b/inc/fields/choice.php
@@ -10,18 +10,6 @@
  */
 abstract class RWMB_Choice_Field extends RWMB_Field {
 	/**
-	 * Walk options.
-	 *
-	 * @param array $field   Field parameters.
-	 * @param mixed $options Field options.
-	 * @param mixed $meta    Meta value.
-	 * @return string
-	 */
-	public static function walk( $field, $options, $meta ) {
-		return '';
-	}
-
-	/**
 	 * Get field HTML.
 	 *
 	 * @param mixed $meta  Meta value.
@@ -29,7 +17,7 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	 * @return string
 	 */
 	public static function html( $meta, $field ) {
-		return self::call( 'walk', $field, $field['options_transformed'], (array) $meta );
+		return '';
 	}
 
 	/**

--- a/inc/fields/choice.php
+++ b/inc/fields/choice.php
@@ -96,11 +96,9 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	 * @return array
 	 */
 	public static function filter_options( $field, $options ) {
-		$db_fields = self::call( 'get_db_fields', $field );
-		$label     = $db_fields['label'];
 		foreach ( $options as &$option ) {
-			$option         = apply_filters( 'rwmb_option', $option, $field );
-			$option->$label = apply_filters( 'rwmb_option_label', $option->$label, $option, $field );
+			$option        = apply_filters( 'rwmb_option', $option, $field );
+			$option->label = apply_filters( 'rwmb_option_label', $option->label, $option, $field );
 		}
 		return $options;
 	}

--- a/inc/fields/choice.php
+++ b/inc/fields/choice.php
@@ -12,13 +12,12 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	/**
 	 * Walk options.
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
+	public static function walk( $field, $options, $meta ) {
 		return '';
 	}
 
@@ -30,11 +29,7 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	 * @return string
 	 */
 	public static function html( $meta, $field ) {
-		$meta      = (array) $meta;
-		$options   = self::call( 'get_options', $field );
-		$options   = self::call( 'filter_options', $field, $options );
-		$db_fields = self::call( 'get_db_fields', $field );
-		return ! empty( $options ) ? self::call( 'walk', $field, $options, $db_fields, $meta ) : null;
+		return self::call( 'walk', $field, $field['options_transformed'], (array) $meta );
 	}
 
 	/**
@@ -50,57 +45,31 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 			'options' => array(),
 		) );
 
+		$field['options_transformed'] = self::transform_options( $field['options'] );
+
 		return $field;
 	}
 
 	/**
-	 * Get field names of object to be used by walker.
+	 * Transform field options into the verbose format.
+	 *
+	 * @param array $options Field options.
 	 *
 	 * @return array
 	 */
-	public static function get_db_fields() {
-		return array(
-			'parent' => 'parent',
-			'id'     => 'value',
-			'label'  => 'label',
-		);
-	}
-
-	/**
-	 * Get options for walker.
-	 *
-	 * @param array $field Field parameters.
-	 *
-	 * @return array
-	 */
-	public static function get_options( $field ) {
-		$options = array();
-		foreach ( (array) $field['options'] as $value => $label ) {
+	public static function transform_options( $options ) {
+		$transformed = array();
+		$options     = (array) $options;
+		foreach ( $options as $value => $label ) {
 			$option = is_array( $label ) ? $label : array(
 				'label' => (string) $label,
 				'value' => (string) $value,
 			);
 			if ( isset( $option['label'] ) && isset( $option['value'] ) ) {
-				$options[ $option['value'] ] = (object) $option;
+				$transformed[ $option['value'] ] = (object) $option;
 			}
 		}
-		return $options;
-	}
-
-	/**
-	 * Filter options for walker.
-	 *
-	 * @param array $field   Field parameters.
-	 * @param array $options Array of choice options.
-	 *
-	 * @return array
-	 */
-	public static function filter_options( $field, $options ) {
-		foreach ( $options as &$option ) {
-			$option        = apply_filters( 'rwmb_option', $option, $field );
-			$option->label = apply_filters( 'rwmb_option_label', $option->label, $option, $field );
-		}
-		return $options;
+		return $transformed;
 	}
 
 	/**
@@ -126,7 +95,7 @@ abstract class RWMB_Choice_Field extends RWMB_Field {
 	 * @return string
 	 */
 	public static function get_option_label( $field, $value ) {
-		$options = self::call( 'get_options', $field );
+		$options = $field['options_transformed'];
 		return isset( $options[ $value ] ) ? $options[ $value ]->label : '';
 	}
 }

--- a/inc/fields/input-list.php
+++ b/inc/fields/input-list.php
@@ -18,22 +18,20 @@ class RWMB_Input_List_Field extends RWMB_Choice_Field {
 	}
 
 	/**
-	 * Walk options.
+	 * Get field HTML.
 	 *
-	 * @param array $field   Field parameters.
-	 * @param mixed $options Field options.
-	 * @param mixed $meta    Meta value.
-	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $meta ) {
+	public static function html( $meta, $field ) {
 		$walker = new RWMB_Walker_Input_List( $field, $meta );
 		$output = self::get_select_all_html( $field );
 		$output .= sprintf( '<ul class="rwmb-input-list %s %s">',
 			$field['collapse'] ? 'collapse' : '',
 			$field['inline'] ? 'inline' : ''
 		);
-		$output .= $walker->walk( $options, $field['flatten'] ? - 1 : 0 );
+		$output .= $walker->walk( $field['options_transformed'], $field['flatten'] ? -1 : 0 );
 		$output .= '</ul>';
 
 		return $output;

--- a/inc/fields/input-list.php
+++ b/inc/fields/input-list.php
@@ -20,15 +20,14 @@ class RWMB_Input_List_Field extends RWMB_Choice_Field {
 	/**
 	 * Walk options.
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 *
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
-		$walker = new RWMB_Walker_Input_List( $db_fields, $field, $meta );
+	public static function walk( $field, $options, $meta ) {
+		$walker = new RWMB_Walker_Input_List( $field, $meta );
 		$output = self::get_select_all_html( $field );
 		$output .= sprintf( '<ul class="rwmb-input-list %s %s">',
 			$field['collapse'] ? 'collapse' : '',

--- a/inc/fields/object-choice.php
+++ b/inc/fields/object-choice.php
@@ -10,15 +10,14 @@
  */
 abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 	/**
-	 * Get field HTML
+	 * Get field HTML.
 	 *
-	 * @param array $field   Field parameters.
-	 * @param mixed $options Field options.
-	 * @param mixed $meta    Meta value.
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $meta ) {
-		return call_user_func( array( self::get_type_class( $field ), 'walk' ), $field, $options, $meta );
+	public static function html( $meta, $field ) {
+		return call_user_func( array( self::get_type_class( $field ), 'html' ), $meta, $field );
 	}
 
 	/**

--- a/inc/fields/object-choice.php
+++ b/inc/fields/object-choice.php
@@ -12,14 +12,13 @@ abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 	/**
 	 * Get field HTML
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
-		return call_user_func( array( self::get_type_class( $field ), 'walk' ), $field, $options, $db_fields, $meta );
+	public static function walk( $field, $options, $meta ) {
+		return call_user_func( array( self::get_type_class( $field ), 'walk' ), $field, $options, $meta );
 	}
 
 	/**

--- a/inc/fields/object-choice.php
+++ b/inc/fields/object-choice.php
@@ -69,19 +69,6 @@ abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 	}
 
 	/**
-	 * Get field names of object to be used by walker.
-	 *
-	 * @return array
-	 */
-	public static function get_db_fields() {
-		return array(
-			'parent' => '',
-			'id'     => '',
-			'label'  => '',
-		);
-	}
-
-	/**
 	 * Enqueue scripts and styles.
 	 */
 	public static function admin_enqueue_scripts() {

--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -58,6 +58,7 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 
 	/**
 	 * Query posts for field options.
+	 *
 	 * @param  array $field Field settings.
 	 * @return array        Field options array.
 	 */
@@ -73,7 +74,7 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 		$query   = new WP_Query( $args );
 		$options = array();
 		foreach ( $query->posts as $post ) {
-			$options[$post->ID] = array(
+			$options[ $post->ID ] = array(
 				'value'  => $post->ID,
 				'label'  => $post->post_title,
 				'parent' => $post->post_parent,

--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -100,15 +100,17 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Get option label.
+	 * Format a single value for the helper functions. Sub-fields should overwrite this method if necessary.
 	 *
-	 * @param array  $field Field parameters.
-	 * @param string $value Option value.
+	 * @param array    $field   Field parameters.
+	 * @param string   $value   The value.
+	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
+	 * @param int|null $post_id Post ID. null for current post. Optional.
 	 *
 	 * @return string
 	 */
-	public static function get_option_label( $field, $value ) {
-		return sprintf(
+	public static function format_single_value( $field, $value, $args, $post_id ) {
+		return ! $value ? '' : sprintf(
 			'<a href="%s" title="%s">%s</a>',
 			esc_url( get_permalink( $value ) ),
 			the_title_attribute( array(

--- a/inc/fields/select-tree.php
+++ b/inc/fields/select-tree.php
@@ -12,15 +12,14 @@ class RWMB_Select_Tree_Field extends RWMB_Select_Field {
 	/**
 	 * Walk options.
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 *
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
-		$walker = new RWMB_Walker_Select_Tree( $db_fields, $field, $meta );
+	public static function walk( $field, $options, $meta ) {
+		$walker = new RWMB_Walker_Select_Tree( $field, $meta );
 		return $walker->walk( $options );
 	}
 

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -20,23 +20,22 @@ class RWMB_Select_Field extends RWMB_Choice_Field {
 	/**
 	 * Walk options.
 	 *
-	 * @param array $field     Field parameters.
-	 * @param mixed $options   Select options.
-	 * @param mixed $db_fields Database fields to use in the output.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field   Field parameters.
+	 * @param mixed $options Field options.
+	 * @param mixed $meta    Meta value.
 	 *
 	 * @return string
 	 */
-	public static function walk( $field, $options, $db_fields, $meta ) {
+	public static function walk( $field, $options, $meta ) {
 		$attributes                  = self::call( 'get_attributes', $field, $meta );
 		$attributes['data-selected'] = $meta;
-		$walker                      = new RWMB_Walker_Select( $db_fields, $field, $meta );
+		$walker                      = new RWMB_Walker_Select( $field, $meta );
 		$output                      = sprintf(
 			'<select %s>',
 			self::render_attributes( $attributes )
 		);
-		if ( false === $field['multiple'] ) {
-			$output .= $field['placeholder'] ? '<option value="">' . esc_html( $field['placeholder'] ) . '</option>' : '';
+		if ( ! $field['multiple'] && $field['placeholder'] ) {
+			$output .= '<option value="">' . esc_html( $field['placeholder'] ) . '</option>';
 		}
 		$output .= $walker->walk( $options, $field['flatten'] ? - 1 : 0 );
 		$output .= '</select>';

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -18,15 +18,13 @@ class RWMB_Select_Field extends RWMB_Choice_Field {
 	}
 
 	/**
-	 * Walk options.
+	 * Get field HTML.
 	 *
-	 * @param array $field   Field parameters.
-	 * @param mixed $options Field options.
-	 * @param mixed $meta    Meta value.
-	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
 	 * @return string
 	 */
-	public static function walk( $field, $options, $meta ) {
+	public static function html( $meta, $field ) {
 		$attributes                  = self::call( 'get_attributes', $field, $meta );
 		$attributes['data-selected'] = $meta;
 		$walker                      = new RWMB_Walker_Select( $field, $meta );
@@ -37,7 +35,7 @@ class RWMB_Select_Field extends RWMB_Choice_Field {
 		if ( ! $field['multiple'] && $field['placeholder'] ) {
 			$output .= '<option value="">' . esc_html( $field['placeholder'] ) . '</option>';
 		}
-		$output .= $walker->walk( $options, $field['flatten'] ? - 1 : 0 );
+		$output .= $walker->walk( $field['options_transformed'], $field['flatten'] ? -1 : 0 );
 		$output .= '</select>';
 		$output .= self::get_select_all_html( $field );
 		return $output;

--- a/inc/fields/sidebar.php
+++ b/inc/fields/sidebar.php
@@ -31,6 +31,7 @@ class RWMB_Sidebar_Field extends RWMB_Object_Choice_Field {
 
 	/**
 	 * Get sidebars for field options.
+	 *
 	 * @param  array $field Field settings.
 	 * @return array        Field options array.
 	 */
@@ -38,7 +39,7 @@ class RWMB_Sidebar_Field extends RWMB_Object_Choice_Field {
 		global $wp_registered_sidebars;
 		$options = array();
 		foreach ( $wp_registered_sidebars as $sidebar ) {
-			$options[$sidebar['id']] = array(
+			$options[ $sidebar['id'] ] = array(
 				'value' => $sidebar['id'],
 				'label' => $sidebar['name'],
 			);

--- a/inc/fields/sidebar.php
+++ b/inc/fields/sidebar.php
@@ -17,48 +17,33 @@ class RWMB_Sidebar_Field extends RWMB_Object_Choice_Field {
 	 * @return array
 	 */
 	public static function normalize( $field ) {
-		// Set default field args.
+		$field = wp_parse_args( $field, array(
+			'placeholder' => __( 'Select a sidebar', 'meta-box' ),
+		) );
+
+		// Get sidebars for field options.
+		$field['options'] = self::query( $field );
+
 		$field = parent::normalize( $field );
-
-		// Prevent select tree for user since it's not hierarchical.
-		$field['field_type'] = 'select_tree' === $field['field_type'] ? 'select' : $field['field_type'];
-
-		// Set to always flat.
-		$field['flatten'] = true;
-
-		// Set default placeholder.
-		$field['placeholder'] = empty( $field['placeholder'] ) ? __( 'Select a sidebar', 'meta-box' ) : $field['placeholder'];
 
 		return $field;
 	}
 
 	/**
-	 * Get users.
-	 *
-	 * @param array $field Field parameters.
-	 *
-	 * @return array
+	 * Get sidebars for field options.
+	 * @param  array $field Field settings.
+	 * @return array        Field options array.
 	 */
-	public static function get_options( $field ) {
+	public static function query( $field ) {
 		global $wp_registered_sidebars;
 		$options = array();
 		foreach ( $wp_registered_sidebars as $sidebar ) {
-			$options[] = (object) $sidebar;
+			$options[$sidebar['id']] = array(
+				'value' => $sidebar['id'],
+				'label' => $sidebar['name'],
+			);
 		}
 		return $options;
-	}
-
-	/**
-	 * Get field names of object to be used by walker.
-	 *
-	 * @return array
-	 */
-	public static function get_db_fields() {
-		return array(
-			'parent' => 'parent',
-			'id'     => 'id',
-			'label'  => 'name',
-		);
 	}
 
 	/**

--- a/inc/fields/sidebar.php
+++ b/inc/fields/sidebar.php
@@ -47,14 +47,16 @@ class RWMB_Sidebar_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Get option label.
+	 * Format a single value for the helper functions. Sub-fields should overwrite this method if necessary.
 	 *
-	 * @param array  $field Field parameters.
-	 * @param string $value Option value.
+	 * @param array    $field   Field parameters.
+	 * @param string   $value   The value.
+	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
+	 * @param int|null $post_id Post ID. null for current post. Optional.
 	 *
 	 * @return string
 	 */
-	public static function get_option_label( $field, $value ) {
+	public static function format_single_value( $field, $value, $args, $post_id ) {
 		if ( ! is_active_sidebar( $value ) ) {
 			return '';
 		}

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -164,20 +164,22 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Get option label.
+	 * Format a single value for the helper functions. Sub-fields should overwrite this method if necessary.
 	 *
-	 * @param array  $field Field parameters.
-	 * @param object $value The term object.
+	 * @param array    $field   Field parameters.
+	 * @param string   $value   The value.
+	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
+	 * @param int|null $post_id Post ID. null for current post. Optional.
 	 *
 	 * @return string
 	 */
-	public static function get_option_label( $field, $value ) {
+	public static function format_single_value( $field, $value, $args, $post_id ) {
 		return sprintf(
 			'<a href="%s" title="%s">%s</a>',
 			// @codingStandardsIgnoreLine
 			esc_url( get_term_link( $value ) ),
 			esc_attr( $value->name ),
-			$value->name
+			esc_html( $value->name )
 		);
 	}
 }

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -58,7 +58,7 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 		$field['query_args'] = wp_parse_args( $field['query_args'], array(
 			'hide_empty' => false,
 		) );
-		// Query posts to set field options.
+		// Query terms for field options.
 		$field['options'] = self::query( $field );
 
 		// Prevent cloning for taxonomy field.
@@ -70,7 +70,8 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Query terms to set field options.
+	 * Query terms for field options.
+	 *
 	 * @param  array $field Field settings.
 	 * @return array        Field options array.
 	 */
@@ -87,7 +88,7 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 		}
 		$options = array();
 		foreach ( $terms as $term ) {
-			$options[$term->term_id] = array(
+			$options[ $term->term_id ] = array(
 				'value'  => $term->term_id,
 				'label'  => $term->name,
 				'parent' => $term->parent,

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -29,7 +29,8 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 
 		// Set default field args.
 		$field = wp_parse_args( $field, array(
-			'taxonomy' => 'category',
+			'taxonomy'   => 'category',
+			'query_args' => array(),
 		) );
 
 		// Force taxonomy to be an array.
@@ -52,41 +53,46 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 		$field = wp_parse_args( $field, array(
 			'placeholder' => $placeholder,
 		) );
-		$field = parent::normalize( $field );
 
 		// Set default query args.
 		$field['query_args'] = wp_parse_args( $field['query_args'], array(
 			'hide_empty' => false,
 		) );
+		// Query posts to set field options.
+		$field['options'] = self::query( $field );
 
 		// Prevent cloning for taxonomy field.
 		$field['clone'] = false;
+
+		$field = parent::normalize( $field );
 
 		return $field;
 	}
 
 	/**
-	 * Get field names of object to be used by walker.
-	 *
-	 * @return array
+	 * Query terms to set field options.
+	 * @param  array $field Field settings.
+	 * @return array        Field options array.
 	 */
-	public static function get_db_fields() {
-		return array(
-			'parent' => 'parent',
-			'id'     => 'term_id',
-			'label'  => 'name',
-		);
-	}
-
-	/**
-	 * Get options for selects, checkbox list, etc via the terms.
-	 *
-	 * @param array $field Field parameters.
-	 *
-	 * @return array
-	 */
-	public static function get_options( $field ) {
-		$options = get_terms( $field['taxonomy'], $field['query_args'] );
+	public static function query( $field ) {
+		$args = wp_parse_args( $field['query_args'], array(
+			'taxonomy'               => $field['taxonomy'],
+			'hide_empty'             => false,
+			'count'                  => false,
+			'update_term_meta_cache' => false,
+		) );
+		$terms = get_terms( $args );
+		if ( ! is_array( $terms ) ) {
+			return array();
+		}
+		$options = array();
+		foreach ( $terms as $term ) {
+			$options[$term->term_id] = array(
+				'value'  => $term->term_id,
+				'label'  => $term->name,
+				'parent' => $term->parent,
+			);
+		}
 		return $options;
 	}
 

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -24,7 +24,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 			'display_field' => 'display_name',
 		) );
 
-		// Query posts to set field options.
+		// Query posts for field options.
 		$field['options'] = self::query( $field );
 
 		$field = parent::normalize( $field );
@@ -33,7 +33,8 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Query users to set field options.
+	 * Query users for field options.
+	 *
 	 * @param  array $field Field settings.
 	 * @return array        Field options array.
 	 */
@@ -46,7 +47,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		$users   = get_users( $args );
 		$options = array();
 		foreach ( $users as $user ) {
-			$options[$user->ID] = array(
+			$options[ $user->ID ] = array(
 				'value' => $user->ID,
 				'label' => $user->$display_field,
 			);

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -20,49 +20,36 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		// Set default field args.
 		$field = wp_parse_args( $field, array(
 			'placeholder' => __( 'Select an user', 'meta-box' ),
+			'query_args'  => array(),
 		) );
+
+		// Query posts to set field options.
+		$field['options'] = self::query( $field );
+
 		$field = parent::normalize( $field );
-
-		// Prevent select tree for user since it's not hierarchical.
-		$field['field_type'] = 'select_tree' === $field['field_type'] ? 'select' : $field['field_type'];
-
-		// Set to always flat.
-		$field['flatten'] = true;
-
-		// Set default query args.
-		$field['query_args'] = wp_parse_args( $field['query_args'], array(
-			'orderby' => 'display_name',
-			'order'   => 'asc',
-			'role'    => '',
-			'fields'  => 'all',
-		) );
 
 		return $field;
 	}
 
 	/**
-	 * Get users.
-	 *
-	 * @param array $field Field parameters.
-	 *
-	 * @return array
+	 * Query users to set field options.
+	 * @param  array $field Field settings.
+	 * @return array        Field options array.
 	 */
-	public static function get_options( $field ) {
-		$query = new WP_User_Query( $field['query_args'] );
-		return $query->get_results();
-	}
-
-	/**
-	 * Get field names of object to be used by walker.
-	 *
-	 * @return array
-	 */
-	public static function get_db_fields() {
-		return array(
-			'parent' => 'parent',
-			'id'     => 'ID',
-			'label'  => 'display_name',
-		);
+	public static function query( $field ) {
+		$args = wp_parse_args( $field['query_args'], array(
+			'orderby' => 'display_name',
+			'order'   => 'asc',
+		) );
+		$users   = get_users( $args );
+		$options = array();
+		foreach ( $users as $user ) {
+			$options[$user->ID] = array(
+				'value' => $user->ID,
+				'label' => $user->display_name,
+			);
+		}
+		return $options;
 	}
 
 	/**

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -19,8 +19,9 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 	public static function normalize( $field ) {
 		// Set default field args.
 		$field = wp_parse_args( $field, array(
-			'placeholder' => __( 'Select an user', 'meta-box' ),
-			'query_args'  => array(),
+			'placeholder'   => __( 'Select an user', 'meta-box' ),
+			'query_args'    => array(),
+			'display_field' => 'display_name',
 		) );
 
 		// Query posts to set field options.
@@ -37,8 +38,9 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 	 * @return array        Field options array.
 	 */
 	public static function query( $field ) {
+		$display_field = $field['display_field'];
 		$args = wp_parse_args( $field['query_args'], array(
-			'orderby' => 'display_name',
+			'orderby' => $display_field,
 			'order'   => 'asc',
 		) );
 		$users   = get_users( $args );
@@ -46,7 +48,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		foreach ( $users as $user ) {
 			$options[$user->ID] = array(
 				'value' => $user->ID,
-				'label' => $user->display_name,
+				'label' => $user->$display_field,
 			);
 		}
 		return $options;
@@ -61,7 +63,8 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 	 * @return string
 	 */
 	public static function get_option_label( $field, $value ) {
-		$user  = get_userdata( $value );
-		return '<a href="' . get_author_posts_url( $value ) . '">' . $user->display_name . '</a>';
+		$display_field = $field['display_field'];
+		$user          = get_userdata( $value );
+		return '<a href="' . get_author_posts_url( $value ) . '">' . $user->$display_field . '</a>';
 	}
 }

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -55,16 +55,18 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 	}
 
 	/**
-	 * Get option label.
+	 * Format a single value for the helper functions. Sub-fields should overwrite this method if necessary.
 	 *
-	 * @param array  $field Field parameters.
-	 * @param string $value Option value.
+	 * @param array    $field   Field parameters.
+	 * @param string   $value   The value.
+	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
+	 * @param int|null $post_id Post ID. null for current post. Optional.
 	 *
 	 * @return string
 	 */
-	public static function get_option_label( $field, $value ) {
+	public static function format_single_value( $field, $value, $args, $post_id ) {
 		$display_field = $field['display_field'];
 		$user          = get_userdata( $value );
-		return '<a href="' . get_author_posts_url( $value ) . '">' . $user->$display_field . '</a>';
+		return '<a href="' . esc_url( get_author_posts_url( $value ) ) . '">' . esc_html( $user->$display_field ) . '</a>';
 	}
 }

--- a/inc/walkers/base.php
+++ b/inc/walkers/base.php
@@ -11,35 +11,32 @@
  */
 abstract class RWMB_Walker_Base extends Walker {
 	/**
-	 * Field data.
+	 * Field settings.
 	 *
-	 * @access public
 	 * @var array
 	 */
 	public $field;
 
 	/**
-	 * Meta data.
+	 * Field meta data.
 	 *
-	 * @access public
 	 * @var array
 	 */
-	public $meta = array();
+	public $meta;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param array $db_fields Database fields.
-	 * @param array $field     Field parameters.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field Field parameters.
+	 * @param mixed $meta  Meta value.
 	 */
-	public function __construct( $db_fields, $field, $meta ) {
-		$this->db_fields = wp_parse_args( (array) $db_fields, array(
-			'parent' => '',
-			'id'     => '',
-			'label'  => '',
-		) );
-		$this->field     = $field;
-		$this->meta      = (array) $meta;
+	public function __construct( $field, $meta ) {
+		$this->db_fields = array(
+			'id'     => 'value',
+			'parent' => 'parent',
+		);
+
+		$this->field = $field;
+		$this->meta  = (array) $meta;
 	}
 }

--- a/inc/walkers/input-list.php
+++ b/inc/walkers/input-list.php
@@ -41,15 +41,13 @@ class RWMB_Walker_Input_List extends RWMB_Walker_Base {
 	 * @param int    $current_object_id ID of the current item.
 	 */
 	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
-		$label      = $this->db_fields['label'];
-		$id         = $this->db_fields['id'];
-		$attributes = RWMB_Field::call( 'get_attributes', $this->field, $object->$id );
+		$attributes = RWMB_Field::call( 'get_attributes', $this->field, $object->value );
 
 		$output .= sprintf(
 			'<li><label><input %s %s>%s</label>',
 			RWMB_Field::render_attributes( $attributes ),
-			checked( in_array( $object->$id, $this->meta ), 1, false ),
-			RWMB_Field::filter( 'choice_label', $object->$label, $this->field, $object )
+			checked( in_array( $object->value, $this->meta ), true, false ),
+			esc_html( $object->label )
 		);
 	}
 

--- a/inc/walkers/select-tree.php
+++ b/inc/walkers/select-tree.php
@@ -10,7 +10,7 @@
  */
 class RWMB_Walker_Select_Tree {
 	/**
-	 * Field data.
+	 * Field settings.
 	 *
 	 * @var string
 	 */
@@ -21,23 +21,17 @@ class RWMB_Walker_Select_Tree {
 	 *
 	 * @var array
 	 */
-	public $meta = array();
+	public $meta;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param array $db_fields Database fields.
-	 * @param array $field     Field parameters.
-	 * @param mixed $meta      Meta value.
+	 * @param array $field Field parameters.
+	 * @param mixed $meta  Meta value.
 	 */
-	public function __construct( $db_fields, $field, $meta ) {
-		$this->db_fields = wp_parse_args( (array) $db_fields, array(
-			'parent' => '',
-			'id'     => '',
-			'label'  => '',
-		) );
-		$this->field     = $field;
-		$this->meta      = (array) $meta;
+	public function __construct( $field, $meta ) {
+		$this->field = $field;
+		$this->meta  = (array) $meta;
 	}
 
 	/**
@@ -48,15 +42,14 @@ class RWMB_Walker_Select_Tree {
 	 * @return string
 	 */
 	public function walk( $options ) {
-		$parent   = $this->db_fields['parent'];
 		$children = array();
 
 		foreach ( $options as $option ) {
-			$index = isset( $option->$parent ) ? $option->$parent : 0;
+			$index = isset( $option->parent ) ? $option->parent : 0;
 			$children[ $index ][] = $option;
 		}
 
-		$top_level = isset( $children[0] ) ? 0 : $options[0]->$parent;
+		$top_level = isset( $children[0] ) ? 0 : $options[0]->parent;
 		return $this->display_level( $children, $top_level, true );
 	}
 
@@ -70,25 +63,24 @@ class RWMB_Walker_Select_Tree {
 	 * @return string
 	 */
 	public function display_level( $options, $parent_id = 0, $active = false ) {
-		$id         = $this->db_fields['id'];
 		$field      = $this->field;
-		$walker     = new RWMB_Walker_Select( $this->db_fields, $field, $this->meta );
+		$walker     = new RWMB_Walker_Select( $field, $this->meta );
 		$attributes = RWMB_Field::call( 'get_attributes', $field, $this->meta );
 
 		$children = $options[ $parent_id ];
 		$output   = sprintf(
 			'<div class="rwmb-select-tree %s" data-parent-id="%s"><select %s>',
 			$active ? '' : 'hidden',
-			$parent_id,
+			esc_attr( $parent_id ),
 			RWMB_Field::render_attributes( $attributes )
 		);
-		$output .= isset( $field['placeholder'] ) ? "<option value=''>{$field['placeholder']}</option>" : '<option></option>';
+		$output .= $field['placeholder'] ? "<option value=''>{$field['placeholder']}</option>" : '<option></option>';
 		$output .= $walker->walk( $children, - 1 );
 		$output .= '</select>';
 
-		foreach ( $children as $c ) {
-			if ( isset( $options[ $c->$id ] ) ) {
-				$output .= $this->display_level( $options, $c->$id, in_array( $c->$id, $this->meta ) && $active );
+		foreach ( $children as $child ) {
+			if ( isset( $options[ $child->value ] ) ) {
+				$output .= $this->display_level( $options, $child->value, in_array( $child->value, $this->meta ) && $active );
 			}
 		}
 

--- a/inc/walkers/select.php
+++ b/inc/walkers/select.php
@@ -21,17 +21,15 @@ class RWMB_Walker_Select extends RWMB_Walker_Base {
 	 * @param int    $current_object_id ID of the current item.
 	 */
 	public function start_el( &$output, $object, $depth = 0, $args = array(), $current_object_id = 0 ) {
-		$label  = $this->db_fields['label'];
-		$id     = $this->db_fields['id'];
 		$meta   = $this->meta;
 		$indent = str_repeat( '&nbsp;', $depth * 4 );
 
 		$output .= sprintf(
 			'<option value="%s" %s>%s%s</option>',
-			esc_attr( $object->$id ),
-			selected( in_array( $object->$id, $meta ), true, false ),
+			esc_attr( $object->value ),
+			selected( in_array( $object->value, $meta ), true, false ),
 			$indent,
-			esc_html( RWMB_Field::filter( 'choice_label', $object->$label, $this->field, $object ) )
+			esc_html( $object->label )
 		);
 	}
 }


### PR DESCRIPTION
Optimize object fields (post, user, taxonomy):

- Do not perform any extra query for clones. Only one query when fields are initialized.
- Reduce complexity in walkers and how fields call walkers to set label & value