### PR TITLE
Fix is_saved() when creating new post

### DIFF
--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -405,11 +405,11 @@ class RW_Meta_Box {
 	 * @return bool
 	 */
 	public function is_saved() {
-		foreach ($this->fields as $field) {
-			if ( empty($field['id']) ) {
+		foreach ( $this->fields as $field ) {
+			if ( empty( $field['id'] ) ) {
 				continue;
 			}
-			if ( $field['storage']->exists($this->object_id, $field['id']) ) {
+			if ( $field['storage']->exists( $this->object_id, $field['id'] ) ) {
 				return true;
 			}
 		}

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -405,16 +405,16 @@ class RW_Meta_Box {
 	 * @return bool
 	 */
 	public function is_saved() {
-			foreach ($this->fields as $field) {
-					if (empty($field['id'])) {
-							continue;
-					}
-					if ($field['storage']->exists($this->object_id, $field['id'])) {
-							return true;
-					}
+		foreach ($this->fields as $field) {
+			if ( empty($field['id']) ) {
+				continue;
 			}
+			if ( $field['storage']->exists($this->object_id, $field['id']) ) {
+				return true;
+			}
+		}
 
-			return false;
+		return false;
 	}
 
 	/**

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -409,8 +409,23 @@ class RW_Meta_Box {
 			if ( empty( $field['id'] ) ) {
 				continue;
 			}
-			if ( $field['storage']->exists( $this->object_id, $field['id'] ) ) {
-				return true;
+
+			if ( method_exists( $field['storage'], 'exists' ) ) {
+			    if ( $field['storage']->exists( $this->object_id, $field['id'] ) ) {
+					return true;
+				}
+			} else {
+			    $value = RWMB_Field::call( $field, 'raw_meta', $this->object_id );
+	 			if ( false === $value ) {
+	 				continue;
+	 			}
+
+	 			if (
+	 				( ! $field['multiple'] && '' !== $value )
+	 				|| ( $field['multiple'] && is_array( $value ) && array() !== $value )
+	 			) {
+	 				return true;
+	 			}
 			}
 		}
 

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -405,23 +405,16 @@ class RW_Meta_Box {
 	 * @return bool
 	 */
 	public function is_saved() {
-		foreach ( $this->fields as $field ) {
-			if ( empty( $field['id'] ) ) {
-				continue;
+			foreach ($this->fields as $field) {
+					if (empty($field['id'])) {
+							continue;
+					}
+					if ($field['storage']->exists($this->object_id, $field['id'])) {
+							return true;
+					}
 			}
-			$value = RWMB_Field::call( $field, 'raw_meta', $this->object_id );
-			if ( false === $value ) {
-				continue;
-			}
-			if (
-				( ! $field['multiple'] && '' !== $value )
-				|| ( $field['multiple'] && is_array( $value ) && array() !== $value )
-			) {
-				return true;
-			}
-		}
 
-		return false;
+			return false;
 	}
 
 	/**

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -411,21 +411,22 @@ class RW_Meta_Box {
 			}
 
 			if ( method_exists( $field['storage'], 'exists' ) ) {
-			    if ( $field['storage']->exists( $this->object_id, $field['id'] ) ) {
+				if ( $field['storage']->exists( $this->object_id, $field['id'] ) ) {
 					return true;
 				}
 			} else {
-			    $value = RWMB_Field::call( $field, 'raw_meta', $this->object_id );
-	 			if ( false === $value ) {
-	 				continue;
-	 			}
+				$value = RWMB_Field::call( $field, 'raw_meta', $this->object_id );
+				
+				if ( false === $value ) {
+					continue;
+				}
 
-	 			if (
-	 				( ! $field['multiple'] && '' !== $value )
-	 				|| ( $field['multiple'] && is_array( $value ) && array() !== $value )
-	 			) {
-	 				return true;
-	 			}
+				if (
+					( ! $field['multiple'] && '' !== $value )
+					|| ( $field['multiple'] && is_array( $value ) && array() !== $value )
+				) {
+					return true;
+				}
 			}
 		}
 

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -416,7 +416,7 @@ class RW_Meta_Box {
 				}
 			} else {
 				$value = RWMB_Field::call( $field, 'raw_meta', $this->object_id );
-				
+
 				if ( false === $value ) {
 					continue;
 				}

--- a/inc/storages/base.php
+++ b/inc/storages/base.php
@@ -44,8 +44,8 @@ class RWMB_Base_Storage implements RWMB_Storage_Interface {
 	/**
 	 * Determine if a meta key is set for a given object
 	 *
-	 * @param int        $object_id ID of the object metadata is for.
-	 * @param string     $meta_key  Metadata key.
+	 * @param int    $object_id ID of the object metadata is for.
+	 * @param string $meta_key  Metadata key.
 	 * @return bool True if exists.
 	 *
 	 * @see metadata_exists()

--- a/inc/storages/base.php
+++ b/inc/storages/base.php
@@ -42,6 +42,19 @@ class RWMB_Base_Storage implements RWMB_Storage_Interface {
 	}
 
 	/**
+	 * Determine if a meta key is set for a given object
+	 *
+	 * @param int        $object_id ID of the object metadata is for.
+	 * @param string     $meta_key  Metadata key.
+	 * @return bool True if exists.
+	 *
+	 * @see metadata_exists()
+	 */
+	public function exists( $object_id, $meta_key ) {
+		return metadata_exists( $this->object_type, $object_id, $meta_key );
+	}
+
+	/**
 	 * Add metadata
 	 *
 	 * @param int    $object_id  ID of the object metadata is for.


### PR DESCRIPTION
When is adding new post (any type) then is_saved() is always returned as true.
It is behavior of https://codex.wordpress.org/Function_Reference/get_metadata because every new post is autosaved, it has an ID in autosave state. get_metadata returns always empty string for non-existed key. False is returned only when object_id and meta_type doesn't exists. It never happens.

But WP has helper function to check if key really exists https://developer.wordpress.org/reference/functions/metadata_exists/