### PR TITLE
Check osm

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -363,7 +363,13 @@ abstract class RWMB_Field {
 			}
 			return;
 		}
-
+		// Date format when saving
+		if ( $field['js_options']['formatSave'] ) {
+			$dateFormat = strtr( $field['js_options']['formatSave'], RWMB_Datetime_Field::$date_formats );
+			$date = date_create( $new );
+			$new = date_format( $date, $dateFormat );
+		}
+		
 		// Default: just update post meta.
 		$storage->update( $post_id, $name, $new );
 	}

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -153,6 +153,13 @@ class RWMB_Datetime_Field extends RWMB_Text_Field {
 	 */
 	public static function meta( $post_id, $saved, $field ) {
 		$meta = parent::meta( $post_id, $saved, $field );
+
+		if ( $field['js_options']['dateFormat'] ) {
+			$dateFormat = strtr( $field['js_options']['dateFormat'], self::$date_formats );
+			$date = date_create( $meta );
+			$meta = date_format( $date, $dateFormat );
+		}
+		
 		if ( $field['timestamp'] ) {
 			$meta = self::prepare_meta( $meta, $field );
 		}

--- a/js/osm.js
+++ b/js/osm.js
@@ -1,10 +1,6 @@
 ( function( $, L ) {
 	'use strict';
 
-	var osmTileLayer = L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-	} );
-
 	// Use function construction to store map & DOM elements separately for each instance
 	var OsmField = function ( $container ) {
 		this.$container = $container;
@@ -43,11 +39,10 @@
 				center: latLng,
 				zoom: 14
 			} );
-			// this.map.addLayer( osmTileLayer );
 
-			L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			L.tileLayer( 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-			}).addTo(this.map);
+			} ).addTo( this.map );
 			
 			this.marker = L.marker( latLng, {
 				draggable: true

--- a/js/osm.js
+++ b/js/osm.js
@@ -43,7 +43,12 @@
 				center: latLng,
 				zoom: 14
 			} );
-			this.map.addLayer( osmTileLayer );
+			// this.map.addLayer( osmTileLayer );
+
+			L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+			}).addTo(this.map);
+			
 			this.marker = L.marker( latLng, {
 				draggable: true
 			} ).addTo( this.map );


### PR DESCRIPTION
Fixed OSM field not working in cloneable groups.

The bug is the OSM tile object is attached to the latest map instance. By creating the tile object for each map instance, the bug is gone.