### PR TITLE
Allows to add new term for `taxonomy` and `taxonomy_advanced` fields

### DIFF
--- a/css/taxonomy.css
+++ b/css/taxonomy.css
@@ -1,6 +1,6 @@
 .rwmb-taxonomy-add,
 .rwmb-taxonomy-add-form {
-	margin-top: 12px;
+	margin-top: 6px;
 }
 .rwmb-taxonomy-add-button {
 	padding: 0;

--- a/css/taxonomy.css
+++ b/css/taxonomy.css
@@ -1,3 +1,18 @@
-.category-add.closed {
+.rwmb-taxonomy-add,
+.rwmb-taxonomy-add-form {
+	margin-top: 12px;
+}
+.rwmb-taxonomy-add-button {
+	padding: 0;
+	border: 0;
+	background: none;
+	color: #0073aa;
+	text-decoration: underline;
+	cursor: pointer;
+}
+.rwmb-taxonomy-add-button:hover {
+	color: #00a0d2;
+}
+.rwmb-taxonomy-add-form.rwmb-hidden {
 	display: none;
 }

--- a/css/taxonomy.css
+++ b/css/taxonomy.css
@@ -1,6 +1,3 @@
 .category-add.closed {
 	display: none;
 }
-.category-add {
-
-}

--- a/css/taxonomy.css
+++ b/css/taxonomy.css
@@ -1,0 +1,6 @@
+.category-add.closed {
+	display: none;
+}
+.category-add {
+
+}

--- a/inc/fields/object-choice.php
+++ b/inc/fields/object-choice.php
@@ -32,7 +32,11 @@ abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 	 */
 	public static function html( $meta, $field ) {
 		$html  = call_user_func( array( self::get_type_class( $field ), 'html' ), $meta, $field );
-		$html .= self::call( 'add_new_form', $field );
+
+		if ( $field['add_new'] ) {
+			$html .= self::call( 'add_new_form', $field );
+		}
+
 		return $html;
 	}
 
@@ -61,6 +65,7 @@ abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 				'flatten'    => true,
 				'query_args' => array(),
 				'field_type' => 'select_advanced',
+				'add_new'    => false,
 			)
 		);
 

--- a/inc/fields/taxonomy-advanced.php
+++ b/inc/fields/taxonomy-advanced.php
@@ -21,7 +21,9 @@ class RWMB_Taxonomy_Advanced_Field extends RWMB_Taxonomy_Field {
 	 * @return string
 	 */
 	public static function value( $new, $old, $post_id, $field ) {
-		return implode( ',', array_filter( array_unique( (array) $new ) ) );
+		$new = parent::value( $new, $old, $post_id, $field );
+
+		return implode( ',', $new );
 	}
 
 	/**

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -124,6 +124,14 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 		if ( empty( $field['id'] ) || ! $field['save_field'] ) {
 			return;
 		}
+
+		if ( $_POST['rwmb-new-category'] ) {
+			$cate_name = $_POST['rwmb-new-category'];
+			$my_cat = array('cat_name' => $cate_name, 'category_nicename' => 'category-slug');
+			// Create the category
+			$cate_id = wp_insert_category( $my_cat );
+		}
+
 		$new = array_unique( array_map( 'intval', (array) $new ) );
 		$new = empty( $new ) ? null : $new;
 
@@ -208,5 +216,39 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 			esc_attr( $value->name ),
 			esc_html( $value->name )
 		);
+	}
+
+	/**
+	 * Get field HTML.
+	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
+	 * @return string
+	 */
+	public static function html( $meta, $field ) {
+		$html  = call_user_func( array( self::get_type_class( $field ), 'html' ), $meta, $field );
+		$html .= self::call( 'add_new_form', $field );
+		$html .= self::html_add_category();
+
+		return $html;
+	}
+	public static function html_add_category() {
+		$html = '';
+		$html .= '<div class="add_new_categories">';
+			$html .= '<a id="rwmb-category-add-toggle" href="#category-add" class="taxonomy-add-new">' .__( '+ Add New Category', 'meta-box' ) .'</a>';
+			$html .= '<div id="category-add" class="category-add closed">';
+				$html .= '<input type="text" name="rwmb-new-category" id="rwmb-newcategory" class="form-required">';
+			$html .= '</div>';
+		$html .= '</div>';
+		return $html;
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public static function admin_enqueue_scripts() {
+		parent::admin_enqueue_scripts();
+		wp_enqueue_style( 'rwmb-taxonomy', RWMB_CSS_URL . 'taxonomy.css', '', RWMB_VER );
+		wp_enqueue_script( 'rwmb-taxonomy', RWMB_JS_URL . 'taxonomy.js', array( 'jquery' ), RWMB_VER, true );
 	}
 }

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -254,12 +254,11 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 			return '';
 		}
 
-		$taxonomy_name = self::get_taxonomy_singular_name( $field );
-
-		// Translators: %s is the taxonomy singular label.
-		$button_text = sprintf( __( 'Add New %s', 'meta-box' ), ucwords( $taxonomy_name ) );
-		// Translators: %s is the taxonomy singular label.
-		$placeholder = sprintf( __( 'Enter new %s name', 'meta-box' ), strtolower( $taxonomy_name ) );
+		$taxonomy        = reset( $field['taxonomy'] );
+		$taxonomy_object = get_taxonomy( $taxonomy );
+		if ( false === $taxonomy_object ) {
+			return '';
+		}
 
 		$html = '
 		<div class="rwmb-taxonomy-add">
@@ -269,8 +268,12 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 			</div>
 		</div>';
 
-		$taxonomy = reset( $field['taxonomy'] );
-		$html     = sprintf( $html, esc_html( $button_text ), esc_attr( $field['id'] ), esc_attr( $placeholder ) );
+		$html = sprintf(
+			$html,
+			esc_html( $taxonomy_object->labels->add_new_item ),
+			esc_attr( $field['id'] ),
+			esc_attr( $taxonomy_object->labels->new_item_name )
+		);
 
 		return $html;
 	}

--- a/js/taxonomy.js
+++ b/js/taxonomy.js
@@ -1,10 +1,8 @@
-jQuery( function ( $, document ) {
+jQuery( function ( $ ) {
 	'use strict';
 
-	$('#rwmb-category-add-toggle').click(function(e){
+	$( document ).on( 'click', '.rwmb-taxonomy-add-button', function( e ) {
 		e.preventDefault();
-		var $this = $( this ).parent();
-		$( '.category-add' ).toggleClass('closed');
-	});
-
+		this.nextElementSibling.classList.toggle( 'rwmb-hidden' );
+	} );
 } );

--- a/js/taxonomy.js
+++ b/js/taxonomy.js
@@ -1,0 +1,10 @@
+jQuery( function ( $, document ) {
+	'use strict';
+
+	$('#rwmb-category-add-toggle').click(function(e){
+		e.preventDefault();
+		var $this = $( this ).parent();
+		$( '.category-add' ).toggleClass('closed');
+	});
+
+} );


### PR DESCRIPTION
Adds a button link "Add new term" to `taxonomy` and `taxonomy_advanced` fields. When click that button, shows the input for entering new term name.

Requires `'add_new' => true`.

Limitation:

- Not working inside group.
- Not working for cloneable fields.