### PR TITLE
Added required jQuery autocomplete to the osm field

### DIFF
--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -20,6 +20,10 @@ class RWMB_OSM_Field extends RWMB_Field {
 
 		wp_enqueue_style( 'rwmb-osm', RWMB_CSS_URL . 'osm.css', array( 'leaflet' ), RWMB_VER );
 		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', array( 'jquery', 'leaflet' ), RWMB_VER, true );
+
+		wp_enqueue_style( 'rwmb-autocomplete', RWMB_CSS_URL . 'autocomplete.css', '', RWMB_VER );
+		wp_enqueue_script( 'rwmb-autocomplete', RWMB_JS_URL . 'autocomplete.js', array( 'jquery-ui-autocomplete' ), RWMB_VER, true );
+
 		RWMB_Helpers_Field::localize_script_once(
 			'rwmb-osm',
 			'RWMB_Osm',
@@ -107,7 +111,7 @@ class RWMB_OSM_Field extends RWMB_Field {
 
 	/**
 	 * Output the field value.
-	 * Display Google maps.
+	 * Display Open Street Map using Leaflet
 	 *
 	 * @param  array    $field   Field parameters.
 	 * @param  array    $args    Additional arguments for the map.

--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -19,10 +19,7 @@ class RWMB_OSM_Field extends RWMB_Field {
 		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.js', array(), '1.5.1', true );
 
 		wp_enqueue_style( 'rwmb-osm', RWMB_CSS_URL . 'osm.css', array( 'leaflet' ), RWMB_VER );
-		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', array( 'jquery', 'leaflet' ), RWMB_VER, true );
-
-		wp_enqueue_style( 'rwmb-autocomplete', RWMB_CSS_URL . 'autocomplete.css', '', RWMB_VER );
-		wp_enqueue_script( 'rwmb-autocomplete', RWMB_JS_URL . 'autocomplete.js', array( 'jquery-ui-autocomplete' ), RWMB_VER, true );
+		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', array( 'jquery', 'jquery-ui-autocomplete', 'leaflet' ), RWMB_VER, true );
 
 		RWMB_Helpers_Field::localize_script_once(
 			'rwmb-osm',

--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -15,8 +15,8 @@ class RWMB_OSM_Field extends RWMB_Field {
 	 */
 	public static function admin_enqueue_scripts() {
 		// Because map is a hosted service, it's ok to use hosted Leaflet scripts.
-		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.3.1/dist/leaflet.css', array(), '1.3.1' );
-		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.3.1/dist/leaflet.js', array(), '1.3.1', true );
+		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.css', array(), '1.5.1' );
+		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.js', array(), '1.5.1', true );
 
 		wp_enqueue_style( 'rwmb-osm', RWMB_CSS_URL . 'osm.css', array( 'leaflet' ), RWMB_VER );
 		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', array( 'jquery', 'leaflet' ), RWMB_VER, true );
@@ -152,13 +152,13 @@ class RWMB_OSM_Field extends RWMB_Field {
 			)
 		);
 
-		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.3.1/dist/leaflet.css', array(), '1.3.1' );
-		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.3.1/dist/leaflet.js', array(), '1.3.1', true );
+		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.css', array(), '1.5.1' );
+		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.js', array(), '1.5.1', true );
 		wp_enqueue_script( 'rwmb-osm-frontend', RWMB_JS_URL . 'osm-frontend.js', array( 'jquery', 'leaflet' ), RWMB_VER, true );
 
 		/*
 		 * More Open Street Map options
-		 * @link https://leafletjs.com/reference-1.3.0.html#map-option
+		 * @link https://leafletjs.com/reference-1.5.0.html#map-option
 		 */
 		$args['js_options'] = wp_parse_args(
 			$args['js_options'],


### PR DESCRIPTION
Enqueue missing style and script for jQuery autocomplete for the Open Street Maps address field
For more information, see issue at: https://metabox.io/support/topic/osm-map-with-user-meta-error-address-autocomplete-is-not-a-function/