### PR TITLE
Remove initial ajax requests to get attachments for media fields

### DIFF
--- a/inc/fields/image-advanced.php
+++ b/inc/fields/image-advanced.php
@@ -19,6 +19,29 @@ class RWMB_Image_Advanced_Field extends RWMB_Media_Field {
 	}
 
 	/**
+	 * Get field HTML.
+	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field parameters.
+	 *
+	 * @return string
+	 */
+	public static function html( $meta, $field ) {
+		$html = parent::html( $meta, $field );
+
+		if ( empty( $meta ) ) {
+			return $html;
+		}
+
+		$meta = array_map( 'wp_prepare_attachment_for_js', $meta );
+		$meta = array_filter( $meta );
+
+		$html .= '<script type="text/html" class="rwmb-data" data-attachments="' . esc_attr( json_encode( $meta ) ) . '"></script>';
+
+		return $html;
+	}
+
+	/**
 	 * Normalize parameters for field.
 	 *
 	 * @param array $field Field parameters.

--- a/inc/fields/image-advanced.php
+++ b/inc/fields/image-advanced.php
@@ -19,29 +19,6 @@ class RWMB_Image_Advanced_Field extends RWMB_Media_Field {
 	}
 
 	/**
-	 * Get field HTML.
-	 *
-	 * @param mixed $meta  Meta value.
-	 * @param array $field Field parameters.
-	 *
-	 * @return string
-	 */
-	public static function html( $meta, $field ) {
-		$html = parent::html( $meta, $field );
-
-		if ( empty( $meta ) ) {
-			return $html;
-		}
-
-		$meta = array_map( 'wp_prepare_attachment_for_js', $meta );
-		$meta = array_filter( $meta );
-
-		$html .= '<script type="text/html" class="rwmb-data" data-attachments="' . esc_attr( json_encode( $meta ) ) . '"></script>';
-
-		return $html;
-	}
-
-	/**
 	 * Normalize parameters for field.
 	 *
 	 * @param array $field Field parameters.

--- a/js/media.js
+++ b/js/media.js
@@ -91,23 +91,6 @@ jQuery( function ( $ ) {
 					this.get( 'items' ).destroyAll();
 				}
 			} );
-		},
-
-
-		// Load initial media
-		load: function () {
-			if ( _.isEmpty( this.get( 'ids' ) ) ) {
-				return;
-			}
-			this.get( 'items' ).props.set( {
-				query: true,
-				include: this.get( 'ids' ),
-				orderby: 'post__in',
-				order: 'ASC',
-				perPage: this.get( 'ids' ).length
-			} );
-			// Get more then trigger ready
-			this.get( 'items' ).more();
 		}
 	} );
 
@@ -142,8 +125,11 @@ jQuery( function ( $ ) {
 			// Render
 			this.render();
 
-			// Load media
-			this.controller.load();
+			// Load initial attachments.
+			var models = this.$input.siblings( '.rwmb-data' ).data( 'attachments' ).map( function( attachment ) {
+				return wp.media.model.Attachment.create( attachment );
+			} );
+			this.controller.get( 'items' ).add( models );
 
 			// Listen for destroy event on input
 			this.$input.on( 'remove', function () {

--- a/js/media.js
+++ b/js/media.js
@@ -104,8 +104,7 @@ jQuery( function ( $ ) {
 				include: this.get( 'ids' ),
 				orderby: 'post__in',
 				order: 'ASC',
-				type: this.get( 'mimeType' ),
-				perPage: this.get( 'maxFiles' ) || - 1
+				perPage: this.get( 'ids' ).length
 			} );
 			// Get more then trigger ready
 			this.get( 'items' ).more();

--- a/js/media.js
+++ b/js/media.js
@@ -126,7 +126,7 @@ jQuery( function ( $ ) {
 			this.render();
 
 			// Load initial attachments.
-			var models = this.$input.siblings( '.rwmb-data' ).data( 'attachments' ).map( function( attachment ) {
+			var models = this.$input.data( 'attachments' ).map( function( attachment ) {
 				return wp.media.model.Attachment.create( attachment );
 			} );
 			this.controller.get( 'items' ).add( models );


### PR DESCRIPTION
Media fields load saved attachments via ajax requests. If a post has a lot of media fields or clones, the number of ajax requests is high and can cause server down.

This PR removes such ajax requests and uses PHP to get attachment data and outputs in the HTML for later use by JS. This method, however, increase the number of queries to the database. But overall, in our test, the performance increases.

See this discussion:

https://metabox.io/support/topic/input-type-image_advanced-vs-image/