### PR TITLE
Update media.js fix for Gutenberg bug

### DIFF
--- a/js/media.js
+++ b/js/media.js
@@ -46,8 +46,8 @@ jQuery( function ( $ ) {
 		},
 
 		remove: function ( models, options ) {
-			// Don't remove models if event came from a Gutenberg component.
-			if( $( event.target ).hasClass( 'components-button' ) || $( event.target ).parents().hasClass( 'components-button' ) ) {
+			// Don't remove models if event is not fired from MB plugin.
+			if( ! $( event.target ).closest( '.rwmb-field, [data-class="rwmb-field"]' ).length ) {
 				return;
 			}
 			models = Backbone.Collection.prototype.remove.call( this, models, options );
@@ -515,6 +515,9 @@ jQuery( function ( $ ) {
 		 */
 		createStates: function () {
 			var options = this.options;
+
+			// Add reference so we know MediaFrame belongs to MB plugin.
+			this.$el.attr( 'data-class', 'rwmb-field' );
 
 			if ( this.options.states ) {
 				return;


### PR DESCRIPTION
Since the first fix used the `components-button` css class as a conditional, it did not take into account Gutenberg blocks with media upload functionality outside of WordPress core.

In this update, the conditional check uses attributes set by the MB plugin. This way, we don't remove models unless the remove was triggered by the MB plugin.

I am guessing the first fix did not work for the forum topic linked below because the media upload blocks were built custom and do not include any reference to the `components-button` css class.

https://metabox.io/support/topic/gutenberg-sidebar-media-upload-clash-with-image_advanced/