### PR TITLE
Blocks

### DIFF
--- a/css/input-list.css
+++ b/css/input-list.css
@@ -1,3 +1,6 @@
+.rwmb-toggle-all-wrapper {
+	margin-top: 0;
+}
 .rwmb-input-list {
 	margin: 0;
 	line-height: 1.8;

--- a/css/style.css
+++ b/css/style.css
@@ -67,6 +67,8 @@
 	position: absolute;
 	top: 0;
 	right: 0;
+	width: 20px;
+	height: 20px;
 }
 .rwmb-button.remove-clone .dashicons {
 	font-size: 14px;

--- a/inc/fields/input-list.php
+++ b/inc/fields/input-list.php
@@ -89,7 +89,7 @@ class RWMB_Input_List_Field extends RWMB_Choice_Field {
 	 */
 	public static function get_select_all_html( $field ) {
 		if ( $field['multiple'] && $field['select_all_none'] ) {
-			return sprintf( '<p><button class="rwmb-input-list-select-all-none button" data-name="%s">%s</button></p>', $field['id'], __( 'Toggle All', 'meta-box' ) );
+			return sprintf( '<p class="rwmb-toggle-all-wrapper"><button class="rwmb-input-list-select-all-none button" data-name="%s">%s</button></p>', $field['id'], __( 'Toggle All', 'meta-box' ) );
 		}
 		return '';
 	}

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -20,6 +20,7 @@ class RWMB_Wysiwyg_Field extends RWMB_Field {
 	 * Enqueue scripts and styles.
 	 */
 	public static function admin_enqueue_scripts() {
+		wp_enqueue_editor();
 		wp_enqueue_style( 'rwmb-wysiwyg', RWMB_CSS_URL . 'wysiwyg.css', array(), RWMB_VER );
 		wp_enqueue_script( 'rwmb-wysiwyg', RWMB_JS_URL . 'wysiwyg.js', array( 'jquery' ), RWMB_VER, true );
 	}

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -151,6 +151,8 @@ class RW_Meta_Box {
 			wp_enqueue_style( 'rwmb-rtl', RWMB_CSS_URL . 'style-rtl.css', array(), RWMB_VER );
 		}
 
+		wp_enqueue_script( 'rwmb', RWMB_JS_URL . 'script.js', array( 'jquery' ), RWMB_VER, true );
+
 		// Load clone script conditionally.
 		foreach ( $this->fields as $field ) {
 			if ( $field['clone'] ) {

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -61,10 +61,10 @@ class RW_Meta_Box {
 	 * @param array $meta_box Meta box definition.
 	 */
 	public function __construct( $meta_box ) {
-		$meta_box       = self::normalize( $meta_box );
+		$meta_box       = static::normalize( $meta_box );
 		$this->meta_box = $meta_box;
 
-		$this->meta_box['fields'] = self::normalize_fields( $meta_box['fields'], $this->get_storage() );
+		$this->meta_box['fields'] = static::normalize_fields( $meta_box['fields'], $this->get_storage() );
 
 		$this->meta_box = apply_filters( 'rwmb_meta_box_settings', $this->meta_box );
 

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -38,7 +38,7 @@
 		} );
 	}
 
-	function delete( e ) {
+	function deleteSelection( e ) {
 		e.preventDefault();
 		$( this ).parent().remove();
 	}
@@ -50,5 +50,5 @@
 	rwmb.$document
 		.on( 'mb_ready', init )
 		.on( 'clone', '.rwmb-autocomplete', updateAutocomplete )
-		.on( 'click', '.rwmb-autocomplete-result .actions', delete );
+		.on( 'click', '.rwmb-autocomplete-result .actions', deleteSelection );
 } )( jQuery, rwmb );

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -1,4 +1,4 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	/**
@@ -38,12 +38,17 @@ jQuery( function ( $ ) {
 		} );
 	}
 
-	$( '.rwmb-autocomplete-wrapper input[type="hidden"]' ).each( updateAutocomplete );
-	$( document )
+	function delete( e ) {
+		e.preventDefault();
+		$( this ).parent().remove();
+	}
+
+	function init( e ) {
+		$( e.target ).find( '.rwmb-autocomplete-wrapper input[type="hidden"]' ).each( updateAutocomplete );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
 		.on( 'clone', '.rwmb-autocomplete', updateAutocomplete )
-		// Handle remove action
-		.on( 'click', '.rwmb-autocomplete-result .actions', function () {
-			// remove result
-			$( this ).parent().remove();
-		} );
-} );
+		.on( 'click', '.rwmb-autocomplete-result .actions', delete );
+} )( jQuery, rwmb );

--- a/js/button-group.js
+++ b/js/button-group.js
@@ -1,7 +1,7 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
-	function update() {
+	function setActiveClass() {
 		var $this = $( this ),
 			$input = $this.find( 'input' ),
 			$label = $input.parent();
@@ -31,7 +31,12 @@ jQuery( function ( $ ) {
 		}
 	}
 
-	$( '.rwmb-button-input-list li' ).each( update );
-	$( document ).on( 'click', '.rwmb-button-input-list li', clickHandler );
-	$( document ).on( 'clone', '.rwmb-button-input-list', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-button-input-list li' ).each( setActiveClass );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'click', '.rwmb-button-input-list li', clickHandler )
+		.on( 'clone', '.rwmb-button-input-list', setActiveClass );
+} )( jQuery, rwmb );

--- a/js/color.js
+++ b/js/color.js
@@ -1,11 +1,10 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	/**
-	 * Update color picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Transform an input into a color picker.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			$container = $this.closest( '.wp-picker-container' ),
 			data = $.extend(
@@ -30,6 +29,11 @@ jQuery( function ( $ ) {
 		$this.wpColorPicker( data );
 	}
 
-	$( '.rwmb-color' ).each( update );
-	$( document ).on( 'clone', '.rwmb-color', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-color' ).each( transform );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-color', transform );
+} )( jQuery, rwmb );

--- a/js/date.js
+++ b/js/date.js
@@ -1,11 +1,10 @@
-jQuery( function ( $ ) {
+( function ( $, _, rwmb ) {
 	'use strict';
 
 	/**
-	 * Update date picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Transform an input into a date picker.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			options = $this.data( 'options' ),
 			$inline = $this.siblings( '.rwmb-datetime-inline' ),
@@ -20,29 +19,29 @@ jQuery( function ( $ ) {
 			};
 		}
 
-		if ( $inline.length ) {
-			options.altField = '#' + $this.attr( 'id' );
-			$this.on( 'keydown', _.debounce( function () {
-				// if val is empty, return to allow empty datepicker input.
-				if ( !$this.val() ) {
-					return;
-				}
-				$picker
-					.datepicker( 'setDate', $this.val() )
-					.find( ".ui-datepicker-current-day" )
-					.trigger( "click" );
-			}, 600 ) );
-
-			$inline
-				.removeClass( 'hasDatepicker' )
-				.empty()
-				.prop( 'id', '' )
-				.datepicker( options )
-				.datepicker( 'setDate', current );
-		}
-		else {
+		if ( ! $inline.length ) {
 			$this.removeClass( 'hasDatepicker' ).datepicker( options );
+			return;
 		}
+
+		options.altField = '#' + $this.attr( 'id' );
+		$this.on( 'keydown', _.debounce( function () {
+			// if val is empty, return to allow empty datepicker input.
+			if ( ! $this.val() ) {
+				return;
+			}
+			$picker
+				.datepicker( 'setDate', $this.val() )
+				.find( '.ui-datepicker-current-day' )
+				.trigger( 'click' );
+		}, 600 ) );
+
+		$inline
+			.removeClass( 'hasDatepicker' )
+			.empty()
+			.prop( 'id', '' )
+			.datepicker( options )
+			.datepicker( 'setDate', current );
 	}
 
 	/**
@@ -53,12 +52,17 @@ jQuery( function ( $ ) {
 	 */
 	function getTimestamp( date ) {
 		if ( date === null ) {
-			return "";
+			return '';
 		}
 		var milliseconds = Date.UTC( date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds() );
 		return Math.floor( milliseconds / 1000 );
 	}
 
-	$( '.rwmb-date' ).each( update );
-	$( document ).on( 'clone', '.rwmb-date', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-date' ).each( transform );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-date', transform );
+} )( jQuery, _, rwmb );

--- a/js/datetime.js
+++ b/js/datetime.js
@@ -1,11 +1,10 @@
-jQuery( function ( $ ) {
+( function ( $, _, rwmb, i18n ) {
 	'use strict';
 
 	/**
-	 * Update datetime picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Transform an input into a datetime picker.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			options = $this.data( 'options' ),
 			$inline = $this.siblings( '.rwmb-datetime-inline' ),
@@ -20,25 +19,29 @@ jQuery( function ( $ ) {
 			};
 		}
 
-		if ( $inline.length ) {
-			options.altField = '#' + $this.attr( 'id' );
-			$this.on( 'keydown', _.debounce( function () {
-				$picker
-					.datepicker( 'setDate', $this.val() )
-					.find( ".ui-datepicker-current-day" )
-					.trigger( "click" );
-			}, 600 ) );
-
-			$inline
-				.removeClass( 'hasDatepicker' )
-				.empty()
-				.prop( 'id', '' )
-				.datetimepicker( options )
-				.datetimepicker( 'setDate', current );
-		}
-		else {
+		if ( ! $inline.length ) {
 			$this.removeClass( 'hasDatepicker' ).datetimepicker( options );
+			return;
 		}
+
+		options.altField = '#' + $this.attr( 'id' );
+		$this.on( 'keydown', _.debounce( function () {
+			// if val is empty, return to allow empty datepicker input.
+			if ( ! $this.val() ) {
+				return;
+			}
+			$picker
+				.datepicker( 'setDate', $this.val() )
+				.find( '.ui-datepicker-current-day' )
+				.trigger( 'click' );
+		}, 600 ) );
+
+		$inline
+			.removeClass( 'hasDatepicker' )
+			.empty()
+			.prop( 'id', '' )
+			.datetimepicker( options )
+			.datetimepicker( 'setDate', current );
 	}
 
 	/**
@@ -49,21 +52,27 @@ jQuery( function ( $ ) {
 	 */
 	function getTimestamp( date ) {
 		if ( date === null ) {
-			return "";
+			return '';
 		}
 		var milliseconds = Date.UTC( date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds() );
 		return Math.floor( milliseconds / 1000 );
 	}
 
 	// Set language if available
-	$.timepicker.setDefaults( $.timepicker.regional[""] );
-	if ( $.timepicker.regional.hasOwnProperty( RWMB_Datetime.locale ) ) {
-		$.timepicker.setDefaults( $.timepicker.regional[RWMB_Datetime.locale] );
-	}
-	else if ( $.timepicker.regional.hasOwnProperty( RWMB_Datetime.localeShort ) ) {
-		$.timepicker.setDefaults( $.timepicker.regional[RWMB_Datetime.localeShort] );
+	function setTimeI18n() {
+		if ( $.timepicker.regional.hasOwnProperty( i18n.locale ) ) {
+			$.timepicker.setDefaults( $.timepicker.regional[i18n.locale] );
+		} else if ( $.timepicker.regional.hasOwnProperty( i18n.localeShort ) ) {
+			$.timepicker.setDefaults( $.timepicker.regional[i18n.localeShort] );
+		}
 	}
 
-	$( '.rwmb-datetime' ).each( update );
-	$( document ).on( 'clone', '.rwmb-datetime', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-datetime' ).each( transform );
+	}
+
+	setTimeI18n();
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-datetime', transform );
+} )( jQuery, _, rwmb, RWMB_Datetime );

--- a/js/file-input.js
+++ b/js/file-input.js
@@ -1,10 +1,9 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
-	var frame,
-		$doc = $( document );
+	var frame;
 
-	$doc.on( 'click', '.rwmb-file-input-select', function ( e ) {
+	function openSelectPopup( e ) {
 		e.preventDefault();
 		var $el = $( this );
 
@@ -28,16 +27,19 @@ jQuery( function ( $ ) {
 			var url = frame.state().get( 'selection' ).first().toJSON().url;
 			$el.siblings( 'input' ).val( url ).siblings( 'a' ).removeClass( 'hidden' );
 		} );
-	} );
+	}
 
-	// Clear selected images
-	$doc.on( 'click', '.rwmb-file-input-remove', function ( e ) {
+	function clearSelection( e ) {
 		e.preventDefault();
 		$( this ).addClass( 'hidden' ).siblings( 'input' ).val( '' );
-	} );
+	}
 
-	// Hide the Remove button when cloning
-	$doc.on( 'clone', '.rwmb-file_input', function () {
+	function hideRemoveButtonWhenCloning() {
 		$( this ).siblings( '.rwmb-file-input-remove' ).addClass( 'hidden' );
-	} );
-} );
+	}
+
+	rwmb.$document
+		.on( 'click', '.rwmb-file-input-select', openSelectPopup )
+		.on( 'click', '.rwmb-file-input-remove', clearSelection )
+		.on( 'clone', '.rwmb-file_input', hideRemoveButtonWhenCloning );
+} )( jQuery, rwmb );

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -1,6 +1,4 @@
-window.rwmb = window.rwmb || {};
-
-jQuery( function ( $ ) {
+( function ( $, wp, rwmb ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -174,17 +172,18 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	/**
-	 * Initialize fields
-	 * @return void
-	 */
-	function init() {
+	function initFileUpload() {
 		var view = new FileUploadField( { input: this } );
 		//Remove old then add new
 		$( this ).siblings( 'div.rwmb-media-view' ).remove();
 		$( this ).after( view.el );
 	}
 
-	$( '.rwmb-file_upload' ).each( init );
-	$( document ).on( 'clone', '.rwmb-file_upload', init )
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-file_upload' ).each( initFileUpload );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-file_upload', initFileUpload )
+} )( jQuery, wp, rwmb );

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -173,10 +173,18 @@
 	} );
 
 	function initFileUpload() {
-		var view = new FileUploadField( { input: this } );
-		//Remove old then add new
-		$( this ).siblings( 'div.rwmb-media-view' ).remove();
-		$( this ).after( view.el );
+		var $this = $( this ),
+			view = $this.data( 'view' );
+
+		if ( view ) {
+			return;
+		}
+
+		view = new FileUploadField( { input: this } );
+
+		$this.siblings( '.rwmb-media-view' ).remove();
+		$this.after( view.el );
+		$this.data( 'view', view );
 	}
 
 	function init( e ) {

--- a/js/file.js
+++ b/js/file.js
@@ -1,5 +1,4 @@
-/* global jQuery */
-( function ( $, document ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	var file = {};
@@ -119,17 +118,19 @@
 		}
 	};
 
-	// Initialize when document ready.
-	$( function ( $ ) {
-		$( document )
-			.on( 'click', '.rwmb-file-add', file.addHandler )
-			.on( 'click', '.rwmb-file-delete', file.deleteHandler )
-			.on( 'clone', '.rwmb-file-input', file.resetClone );
+	function init( e ) {
+		var $el = $( e.target ),
+			$uploaded = $el.find( '.rwmb-uploaded' );
 
-		var $uploaded = $( '.rwmb-uploaded' );
 		$uploaded.each( file.sort );
 		$uploaded.each( file.updateVisibility );
 
-		$( '.rwmb-file-wrapper' ).each( file.setRequired );
-	} );
-} )( jQuery, document );
+		$el.find( '.rwmb-file-wrapper' ).each( file.setRequired );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'click', '.rwmb-file-add', file.addHandler )
+		.on( 'click', '.rwmb-file-delete', file.deleteHandler )
+		.on( 'clone', '.rwmb-file-input', file.resetClone );
+} )( jQuery, rwmb );

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -1,6 +1,4 @@
-window.rwmb = window.rwmb || {};
-
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -40,11 +38,12 @@ jQuery( function ( $ ) {
 		$( this ).siblings( '.rwmb-media-view' ).remove();
 	}
 
-	$( '.rwmb-image_advanced' ).each( initImageField );
-	$( document )
+	function init( e ) {
+		$( e.target ).find( '.rwmb-image_advanced' ).each( initImageField );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
 		.on( 'clone', '.rwmb-image_advanced', removeView )
 		.on( 'after_clone', '.rwmb-image_advanced', initImageField )
-		.on( 'mb_blocks_edit', function( e ) {
-			$( e.target ).find( '.rwmb-image_advanced' ).each( initImageField );
-		} );
-} );
+} )( jQuery, rwmb );

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -28,9 +28,17 @@
 	 */
 	function initImageField() {
 		var $this = $( this ),
-			view = new ImageField( { input: this } );
+			view = $this.data( 'view' );
+
+		if ( view ) {
+			return;
+		}
+
+		view = new ImageField( { input: this } );
+
 		$this.siblings( '.rwmb-media-view' ).remove();
 		$this.after( view.el );
+		$this.data( 'view', view );
 	}
 
 	function init( e ) {

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -44,7 +44,7 @@ jQuery( function ( $ ) {
 	$( document )
 		.on( 'clone', '.rwmb-image_advanced', removeView )
 		.on( 'after_clone', '.rwmb-image_advanced', initImageField )
-		.on( 'rwmb_ready', function() {
-			$( '.rwmb-image_advanced' ).each( initImageField );
+		.on( 'mb_blocks_ready', function( e ) {
+			$( e.target ).find( '.rwmb-image_advanced' ).each( initImageField );
 		} );
 } );

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -44,7 +44,7 @@ jQuery( function ( $ ) {
 	$( document )
 		.on( 'clone', '.rwmb-image_advanced', removeView )
 		.on( 'after_clone', '.rwmb-image_advanced', initImageField )
-		.on( 'mb_blocks_ready', function( e ) {
+		.on( 'mb_blocks_edit', function( e ) {
 			$( e.target ).find( '.rwmb-image_advanced' ).each( initImageField );
 		} );
 } );

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -27,15 +27,10 @@
 	 * Initialize image fields
 	 */
 	function initImageField() {
-		var view = new ImageField( { input: this } );
-		$( this ).after( view.el );
-	}
-
-	/**
-	 * Remove views for uploaded images.
-	 */
-	function removeView() {
-		$( this ).siblings( '.rwmb-media-view' ).remove();
+		var $this = $( this ),
+			view = new ImageField( { input: this } );
+		$this.siblings( '.rwmb-media-view' ).remove();
+		$this.after( view.el );
 	}
 
 	function init( e ) {
@@ -44,6 +39,5 @@
 
 	rwmb.$document
 		.on( 'mb_ready', init )
-		.on( 'clone', '.rwmb-image_advanced', removeView )
-		.on( 'after_clone', '.rwmb-image_advanced', initImageField )
+		.on( 'clone', '.rwmb-image_advanced', initImageField );
 } )( jQuery, rwmb );

--- a/js/image-advanced.js
+++ b/js/image-advanced.js
@@ -43,5 +43,8 @@ jQuery( function ( $ ) {
 	$( '.rwmb-image_advanced' ).each( initImageField );
 	$( document )
 		.on( 'clone', '.rwmb-image_advanced', removeView )
-		.on( 'after_clone', '.rwmb-image_advanced', initImageField );
+		.on( 'after_clone', '.rwmb-image_advanced', initImageField )
+		.on( 'rwmb_ready', function() {
+			$( '.rwmb-image_advanced' ).each( initImageField );
+		} );
 } );

--- a/js/image-select.js
+++ b/js/image-select.js
@@ -1,7 +1,7 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
-	$( 'body' ).on( 'change', '.rwmb-image-select input', function () {
+	function setActiveClass() {
 		var $this = $( this ),
 			type = $this.attr( 'type' ),
 			selected = $this.is( ':checked' ),
@@ -15,6 +15,13 @@ jQuery( function ( $ ) {
 		} else {
 			$parent.removeClass( 'rwmb-active' );
 		}
-	} );
-	$( '.rwmb-image-select input' ).trigger( 'change' );
-} );
+	}
+
+	function init( e ) {
+		$( e.target ).find( '.rwmb-image-select input' ).trigger( 'change' );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'change', '.rwmb-image-select input', setActiveClass );
+} )( jQuery, rwmb );

--- a/js/image-upload.js
+++ b/js/image-upload.js
@@ -1,6 +1,4 @@
-window.rwmb = window.rwmb || {};
-
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -14,18 +12,18 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	/**
-	 * Initialize fields
-	 * @return void
-	 */
-	function init() {
+	function initImageUpload() {
 		var view = new ImageUploadField( { input: this } );
 		//Remove old then add new
 		$( this ).siblings( 'div.rwmb-media-view' ).remove();
 		$( this ).after( view.el );
 	}
 
-	$( '.rwmb-image_upload, .rwmb-plupload_image' ).each( init );
-	$( document )
-		.on( 'clone', '.rwmb-image_upload, .rwmb-plupload_image', init )
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-image_upload, .rwmb-plupload_image' ).each( initImageUpload );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-image_upload, .rwmb-plupload_image', initImageUpload )
+} )( jQuery, rwmb );

--- a/js/image-upload.js
+++ b/js/image-upload.js
@@ -13,10 +13,18 @@
 	} );
 
 	function initImageUpload() {
-		var view = new ImageUploadField( { input: this } );
-		//Remove old then add new
-		$( this ).siblings( 'div.rwmb-media-view' ).remove();
-		$( this ).after( view.el );
+		var $this = $( this ),
+			view = $this.data( 'view' );
+
+		if ( view ) {
+			return;
+		}
+
+		view = new ImageUploadField( { input: this } );
+
+		$this.siblings( '.rwmb-media-view' ).remove();
+		$this.after( view.el );
+		$this.data( 'view', view );
 	}
 
 	function init( e ) {

--- a/js/input-list.js
+++ b/js/input-list.js
@@ -1,24 +1,18 @@
-jQuery( function ( $ ) {
-	function update() {
+( function ( $, rwmb ) {
+	'use strict';
+
+	function toggleTree() {
 		var $this = $( this ),
 			$children = $this.closest( 'li' ).children( 'ul' );
 
 		if ( $this.is( ':checked' ) ) {
 			$children.removeClass( 'hidden' );
 		} else {
-			$children
-				.addClass( 'hidden' )
-				.find( 'input' )
-				.removeAttr( 'checked' );
+			$children.addClass( 'hidden' ).find( 'input' ).prop( 'checked', false );
 		}
 	}
 
-	$( '.rwmb-input' )
-		.on( 'change', '.rwmb-input-list.rwmb-collapse input[type="checkbox"]', update )
-		.on( 'clone', '.rwmb-input-list.rwmb-collapse input[type="checkbox"]', update );
-	$( '.rwmb-input-list.rwmb-collapse input[type="checkbox"]' ).each( update );
-
-	$( document ).on( 'click', '.rwmb-input-list-select-all-none', function( e ) {
+	function toggleAll( e ) {
 		e.preventDefault();
 
 		var $this = $( this ),
@@ -32,5 +26,15 @@ jQuery( function ( $ ) {
 
 		checked = ! checked;
 		$this.data( 'checked', checked );
-	} );
-} );
+	}
+
+	function init( e ) {
+		$( e.target ).find( '.rwmb-input-list.rwmb-collapse input[type="checkbox"]' ).each( toggleTree );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'change', '.rwmb-input-list.rwmb-collapse input[type="checkbox"]', toggleTree )
+		.on( 'clone', '.rwmb-input-list.rwmb-collapse input[type="checkbox"]', toggleTree )
+		.on( 'click', '.rwmb-input-list-select-all-none', toggleAll );
+} )( jQuery, rwmb );

--- a/js/map.js
+++ b/js/map.js
@@ -1,6 +1,4 @@
-/* global google */
-
-(function ( $, document, window, google, i18n ) {
+( function ( $, document, window, google, rwmb, i18n ) {
 	'use strict';
 
 	// Use function construction to store map & DOM elements separately for each instance
@@ -248,23 +246,27 @@
 		}
 	};
 
-	function update() {
-		$( '.rwmb-map-field' ).each( function () {
-			var $this = $( this ),
-				controller = $this.data( 'mapController' );
-			if ( controller ) {
-				return;
-			}
+	function initMap() {
+		var $this = $( this ),
+			controller = $this.data( 'mapController' );
+		if ( controller ) {
+			return;
+		}
 
-			controller = new MapField( $this );
-			controller.init();
-			$this.data( 'mapController', controller );
-		} );
+		controller = new MapField( $this );
+		controller.init();
+		$this.data( 'mapController', controller );
 	}
 
-	$( function () {
-		update();
-		$( '.rwmb-input' ).on( 'clone', update );
-	} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-map-field' ).each( initMap );
+	}
 
-})( jQuery, document, window, google, RWMB_Map );
+	function restart() {
+		$( '.rwmb-map-field' ).each( initMap );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-input', restart );
+} )( jQuery, document, window, google, rwmb, RWMB_Map );

--- a/js/media.js
+++ b/js/media.js
@@ -126,7 +126,11 @@ jQuery( function ( $ ) {
 			this.render();
 
 			// Load initial attachments.
-			var models = this.$input.data( 'attachments' ).map( function( attachment ) {
+			var models = this.$input.data( 'attachments' );
+			if ( ! models ) {
+				models = [];
+			}
+			models = models.map( function( attachment ) {
 				return wp.media.model.Attachment.create( attachment );
 			} );
 			this.controller.get( 'items' ).add( models );

--- a/js/media.js
+++ b/js/media.js
@@ -1,4 +1,4 @@
-( function ( $, wp, rwmb ) {
+( function ( $, wp, _, rwmb, i18n ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -385,7 +385,7 @@
 			}
 		},
 		render: function () {
-			this.$el.html( this.template( {text: i18nRwmbMedia.add} ) );
+			this.$el.html( this.template( {text: i18n.add} ) );
 			return this;
 		},
 
@@ -577,4 +577,4 @@
 	rwmb.$document
 		.on( 'mb_ready', init )
 		.on( 'clone', '.rwmb-file_advanced', initMediaField );
-} )( jQuery, wp, rwmb );
+} )( jQuery, wp, _, rwmb, i18nRwmbMedia );

--- a/js/media.js
+++ b/js/media.js
@@ -1,8 +1,4 @@
-/* global jQuery, _,i18nRwmbMedia */
-
-window.rwmb = window.rwmb || {};
-
-jQuery( function ( $ ) {
+( function ( $, wp, rwmb ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -567,10 +563,6 @@ jQuery( function ( $ ) {
 		}
 	} );
 
-	/**
-	 * Initialize media fields
-	 * @return void
-	 */
 	function initMediaField() {
 		var view = new MediaField( { input: this } );
 		//Remove old then add new
@@ -578,6 +570,11 @@ jQuery( function ( $ ) {
 		$( this ).after( view.el );
 	}
 
-	$( '.rwmb-file_advanced' ).each( initMediaField );
-	$( document ).on( 'clone', '.rwmb-file_advanced', initMediaField );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-file_advanced' ).each( initMediaField );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-file_advanced', initMediaField );
+} )( jQuery, wp, rwmb );

--- a/js/media.js
+++ b/js/media.js
@@ -564,10 +564,18 @@
 	} );
 
 	function initMediaField() {
-		var view = new MediaField( { input: this } );
-		//Remove old then add new
-		$( this ).siblings( 'div.rwmb-media-view' ).remove();
-		$( this ).after( view.el );
+		var $this = $( this ),
+			view = $this.data( 'view' );
+
+		if ( view ) {
+			return;
+		}
+
+		view = new MediaField( { input: this } );
+
+		$this.siblings( '.rwmb-media-view' ).remove();
+		$this.after( view.el );
+		$this.data( 'view', view );
 	}
 
 	function init( e ) {

--- a/js/oembed.js
+++ b/js/oembed.js
@@ -1,4 +1,4 @@
-jQuery( function ( $ ) {
+( function ( $, _, rwmb ) {
 	'use strict';
 
 	/**
@@ -29,7 +29,7 @@ jQuery( function ( $ ) {
 		$( this ).siblings( '.rwmb-embed-media' ).html( '' );
 	}
 
-	$( document )
+	rwmb.$document
 		.on( 'change', '.rwmb-oembed', _.debounce( showPreview, 250 ) )
 	    .on( 'clone', '.rwmb-oembed', removePreview );
-} );
+} )( jQuery, _, rwmb );

--- a/js/osm.js
+++ b/js/osm.js
@@ -1,4 +1,4 @@
-( function( $, L, i18n ) {
+( function( $, L, rwmb, i18n ) {
 	'use strict';
 
 	// Use function construction to store map & DOM elements separately for each instance
@@ -260,23 +260,27 @@
 		}
 	};
 
-	function update() {
-		$( '.rwmb-osm-field' ).each( function () {
-			var $this = $( this ),
-				controller = $this.data( 'osmController' );
-			if ( controller ) {
-				return;
-			}
+	function initOsmMap() {
+		var $this = $( this ),
+			controller = $this.data( 'osmController' );
+		if ( controller ) {
+			return;
+		}
 
-			controller = new OsmField( $this );
-			controller.init();
-			$this.data( 'osmController', controller );
-		} );
+		controller = new OsmField( $this );
+		controller.init();
+		$this.data( 'osmController', controller );
 	}
 
-	$( function () {
-		update();
-		$( '.rwmb-input' ).on( 'clone', update );
-	} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-osm-field' ).each( initOsmMap );
+	}
 
-} )( jQuery, L, RWMB_Osm );
+	function restart() {
+		$( '.rwmb-osm-field' ).each( initOsmMap );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-input', restart );
+} )( jQuery, L, rwmb, RWMB_Osm );

--- a/js/range.js
+++ b/js/range.js
@@ -1,20 +1,23 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	/**
-	 * Update color picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Update text value.
 	 */
 	function update() {
 		var $this = $( this ),
 			$output = $this.siblings( '.rwmb-output' );
 
-		$this.on( 'input propertychange change', function ( e ) {
+		$this.on( 'input propertychange change', function () {
 			$output.html( $this.val() );
 		} );
-
 	}
 
-	$( '.rwmb-range' ).each( update );
-	$( document ).on( 'clone', '.rwmb-range', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-range' ).each( update );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-range', update );
+} )( jQuery, rwmb );

--- a/js/script.js
+++ b/js/script.js
@@ -2,12 +2,12 @@
 	'use strict';
 
 	// Global object for shared functions and data.
-	window.rwmb = {};
+	var rwmb = window.rwmb = {};
 
 	// Trigger a custom ready event for all scripts to hook to.
 	// Used for static DOM and dynamic DOM (loaded in MB Blocks extension for Gutenberg).
-	var $document = $( document );
-	$document.on( 'ready', function() {
-		$document.trigger( 'mb_ready' );
+	rwmb.$document = $( document );
+	rwmb.$document.on( 'ready', function() {
+		rwmb.$document.trigger( 'mb_ready' );
 	} );
 } )( jQuery, document, window );

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,13 @@
+( function( $, document, window ) {
+	'use strict';
+
+	// Global object for shared functions and data.
+	window.rwmb = {};
+
+	// Trigger a custom ready event for all scripts to hook to.
+	// Used for static DOM and dynamic DOM (loaded in MB Blocks extension for Gutenberg).
+	var $document = $( document );
+	$document.on( 'ready', function() {
+		$document.trigger( 'mb_ready' );
+	} );
+} )( jQuery, document, window );

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 // Global object for shared functions and data.
-window.rwmb = rwmb || {};
+window.rwmb = window.rwmb || {};
 
 ( function( $, document, rwmb ) {
 	'use strict';

--- a/js/script.js
+++ b/js/script.js
@@ -1,8 +1,8 @@
-( function( $, document, window ) {
-	'use strict';
+// Global object for shared functions and data.
+window.rwmb = rwmb || {};
 
-	// Global object for shared functions and data.
-	var rwmb = window.rwmb = {};
+( function( $, document, rwmb ) {
+	'use strict';
 
 	// Trigger a custom ready event for all scripts to hook to.
 	// Used for static DOM and dynamic DOM (loaded in MB Blocks extension for Gutenberg).
@@ -10,4 +10,4 @@
 	rwmb.$document.on( 'ready', function() {
 		rwmb.$document.trigger( 'mb_ready' );
 	} );
-} )( jQuery, document, window );
+} )( jQuery, document, rwmb );

--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -31,7 +31,7 @@ jQuery( function ( $ ) {
 		$this.siblings( '.select2-container' ).remove();
 		$this.show().select2( options );
 
-		rwmbSelect.bindEvents( $this );
+		rwmb.select.bindEvents( $this );
 
 		if ( ! $this.attr( 'multiple' ) ) {
 			return;

--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -1,4 +1,4 @@
-jQuery( function ( $ ) {
+( function ( $, document, rwmb ) {
 	'use strict';
 
 	/**
@@ -19,12 +19,9 @@ jQuery( function ( $ ) {
 	}
 
 	/**
-	 * Turn select field into beautiful dropdown with select2 library
-	 * This function is called when document ready and when clone button is clicked (to update the new cloned field)
-	 *
-	 * @return void
+	 * Transform select fields into beautiful dropdown with select2 library.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			options = $this.data( 'options' );
 		$this.removeClass( 'select2-hidden-accessible' );
@@ -50,10 +47,11 @@ jQuery( function ( $ ) {
 		} );
 	}
 
-	$( '.rwmb-select_advanced' ).each( update );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-select_advanced' ).each( transform );
+	}
+
 	$( document )
-		.on( 'clone', '.rwmb-select_advanced', update )
-		.on( 'mb_blocks_edit', function( e ) {
-			$( e.target ).find( '.rwmb-select_advanced' ).each( update );
-		} );
-} );
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-select_advanced', transform );
+} )( jQuery, document, rwmb );

--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -1,4 +1,4 @@
-( function ( $, document, rwmb ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	/**
@@ -49,7 +49,7 @@
 		$( e.target ).find( '.rwmb-select_advanced' ).each( transform );
 	}
 
-	$( document )
+	rwmb.$document
 		.on( 'mb_ready', init )
 		.on( 'clone', '.rwmb-select_advanced', transform );
-} )( jQuery, document, rwmb );
+} )( jQuery, rwmb );

--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -28,8 +28,6 @@
 		$this.siblings( '.select2-container' ).remove();
 		$this.show().select2( options );
 
-		rwmb.selectToggle.bind.apply( this );
-
 		if ( ! $this.attr( 'multiple' ) ) {
 			return;
 		}

--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -31,7 +31,7 @@ jQuery( function ( $ ) {
 		$this.siblings( '.select2-container' ).remove();
 		$this.show().select2( options );
 
-		rwmb.select.bindEvents( $this );
+		rwmb.selectToggle.bind.apply( this );
 
 		if ( ! $this.attr( 'multiple' ) ) {
 			return;
@@ -51,5 +51,9 @@ jQuery( function ( $ ) {
 	}
 
 	$( '.rwmb-select_advanced' ).each( update );
-	$( document ).on( 'clone', '.rwmb-select_advanced', update );
+	$( document )
+		.on( 'clone', '.rwmb-select_advanced', update )
+		.on( 'mb_blocks_edit', function( e ) {
+			$( e.target ).find( '.rwmb-select_advanced' ).each( update );
+		} );
 } );

--- a/js/select-tree.js
+++ b/js/select-tree.js
@@ -1,4 +1,4 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	function setInitialRequiredProp() {
@@ -46,9 +46,15 @@ jQuery( function ( $ ) {
 		toggleTree.call( this );
 	}
 
-	$( '.rwmb-select-tree > select' ).select2();
-	$( '.rwmb-select-tree > select' ).each( setInitialRequiredProp );
-	$( '.rwmb-input' )
+	function init( e ) {
+		var $el = $( e.target );
+
+		$el.find( '.rwmb-select-tree > select' ).select2();
+		$el.find( '.rwmb-select-tree > select' ).each( setInitialRequiredProp );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
 		.on( 'change', '.rwmb-select-tree > select', toggleTree )
 		.on( 'clone', '.rwmb-select-tree > select', instantiateSelect2 );
-} );
+} )( jQuery, rwmb );

--- a/js/select.js
+++ b/js/select.js
@@ -1,3 +1,5 @@
+window.rwmb = rwmb || {};
+
 jQuery( function ( $ ) {
 	'use strict';
 
@@ -6,11 +8,7 @@ jQuery( function ( $ ) {
 	 * Assign to global variable so we can access to this object from select advanced field
 	 */
 	var select = {
-		/**
-		 * Select all/none for select tag
-		 * @param event Click event.
-		 */
-		selectAllNone: function ( event ) {
+		toggleAll: function ( event ) {
 			event.preventDefault();
 			var $this = $( this ),
 				$element = $this.parent().siblings( 'select' );
@@ -27,11 +25,11 @@ jQuery( function ( $ ) {
 		},
 
 		/**
-		 * Add event listener for select all/none links when click
+		 * Add event listener for toggle All links when click
 		 * @param $el jQuery select element
 		 */
 		bindEvents: function ( $el ) {
-			$el.closest( '.rwmb-input' ).on( 'click', '.rwmb-select-all-none a', select.selectAllNone );
+			$el.closest( '.rwmb-input' ).on( 'click', '.rwmb-select-all-none a', select.toggleAll );
 		}
 	};
 
@@ -44,8 +42,12 @@ jQuery( function ( $ ) {
 
 	// Run for select field.
 	$( '.rwmb-select' ).each( update );
-	$( document ).on( 'clone', '.rwmb-select', update );
+	$( document )
+		.on( 'clone', '.rwmb-select', update )
+		.on( 'mb_blocks_edit', function( e ) {
+			$( e.target ).find( '.rwmb-select' ).each( update );
+		} );
 
 	// Export to use for select_advanced.
-	window.rwmbSelect = select;
+	window.rwmb.select = select;
 } );

--- a/js/select.js
+++ b/js/select.js
@@ -1,44 +1,22 @@
-( function ( $, document, rwmb ) {
+( function ( $, document ) {
 	'use strict';
 
-	/**
-	 * Object stores all necessary methods for toggle all actions.
-	 */
-	var selectToggle = {
-		run: function ( e ) {
-			e.preventDefault();
+	function toggleAll( e ) {
+		e.preventDefault();
 
-			var $this = $( this ),
-				$select = $this.parent().siblings( 'select' );
+		var $this = $( this ),
+			$select = $this.parent().siblings( 'select' );
 
-			if ( 'none' === $this.data( 'type' ) ) {
-				$select.val( [] ).trigger( 'change' );
-				return;
-			}
-			var selected = [];
-			$select.find( 'option' ).each( function ( index, option ) {
-				selected.push( option.value );
-			} );
-			$select.val( selected ).trigger( 'change' );
-		},
-
-		/**
-		 * Add event listener for the toggle all link.
-		 * Expect this = select element.
-		 */
-		bind: function () {
-			$( this ).closest( '.rwmb-input' ).on( 'click', '.rwmb-select-all-none a', selectToggle.run );
+		if ( 'none' === $this.data( 'type' ) ) {
+			$select.val( [] ).trigger( 'change' );
+			return;
 		}
+		var selected = [];
+		$select.find( 'option' ).each( function ( index, option ) {
+			selected.push( option.value );
+		} );
+		$select.val( selected ).trigger( 'change' );
 	};
 
-	function init( e ) {
-		$( e.target ).find( '.rwmb-select' ).each( selectToggle.bind );
-	}
-
-	$( document )
-		.on( 'mb_ready', init )
-		.on( 'clone', '.rwmb-select', selectToggle.bind );
-
-	// Export to use for select_advanced.
-	rwmb.selectToggle = selectToggle;
-} )( jQuery, document, rwmb );
+	$( document ).on( 'click', '.rwmb-select-all-none a', toggleAll );
+} )( jQuery, document );

--- a/js/select.js
+++ b/js/select.js
@@ -1,4 +1,4 @@
-( function ( $, document ) {
+( function ( $, rwmb ) {
 	'use strict';
 
 	function toggleAll( e ) {
@@ -18,5 +18,5 @@
 		$select.val( selected ).trigger( 'change' );
 	};
 
-	$( document ).on( 'click', '.rwmb-select-all-none a', toggleAll );
-} )( jQuery, document );
+	rwmb.$document.on( 'click', '.rwmb-select-all-none a', toggleAll );
+} )( jQuery, rwmb );

--- a/js/select.js
+++ b/js/select.js
@@ -1,53 +1,44 @@
-window.rwmb = rwmb || {};
-
-jQuery( function ( $ ) {
+( function ( $, document, rwmb ) {
 	'use strict';
 
 	/**
-	 * Object stores all necessary methods for select All/None actions
-	 * Assign to global variable so we can access to this object from select advanced field
+	 * Object stores all necessary methods for toggle all actions.
 	 */
-	var select = {
-		toggleAll: function ( event ) {
-			event.preventDefault();
+	var selectToggle = {
+		run: function ( e ) {
+			e.preventDefault();
+
 			var $this = $( this ),
-				$element = $this.parent().siblings( 'select' );
+				$select = $this.parent().siblings( 'select' );
 
 			if ( 'none' === $this.data( 'type' ) ) {
-				$element.val( [] ).trigger( 'change' );
+				$select.val( [] ).trigger( 'change' );
 				return;
 			}
 			var selected = [];
-			$element.find( 'option' ).each( function ( index, option ) {
+			$select.find( 'option' ).each( function ( index, option ) {
 				selected.push( option.value );
 			} );
-			$element.val( selected ).trigger( 'change' );
+			$select.val( selected ).trigger( 'change' );
 		},
 
 		/**
-		 * Add event listener for toggle All links when click
-		 * @param $el jQuery select element
+		 * Add event listener for the toggle all link.
+		 * Expect this = select element.
 		 */
-		bindEvents: function ( $el ) {
-			$el.closest( '.rwmb-input' ).on( 'click', '.rwmb-select-all-none a', select.toggleAll );
+		bind: function () {
+			$( this ).closest( '.rwmb-input' ).on( 'click', '.rwmb-select-all-none a', selectToggle.run );
 		}
 	};
 
-	/**
-	 * Update select field when clicking clone button
-	 */
-	function update() {
-		select.bindEvents( $( this ) );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-select' ).each( selectToggle.bind );
 	}
 
-	// Run for select field.
-	$( '.rwmb-select' ).each( update );
 	$( document )
-		.on( 'clone', '.rwmb-select', update )
-		.on( 'mb_blocks_edit', function( e ) {
-			$( e.target ).find( '.rwmb-select' ).each( update );
-		} );
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-select', selectToggle.bind );
 
 	// Export to use for select_advanced.
-	window.rwmb.select = select;
-} );
+	rwmb.selectToggle = selectToggle;
+} )( jQuery, document, rwmb );

--- a/js/slider.js
+++ b/js/slider.js
@@ -1,7 +1,7 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
-	function update() {
+	function transform() {
 		var $input      = $( this ),
 			$slider     = $input.siblings( '.rwmb-slider' ),
 			$valueLabel = $slider.siblings( '.rwmb-slider-value-label' ).find( 'span' ),
@@ -31,6 +31,11 @@ jQuery( function ( $ ) {
 		$slider.slider( options );
 	}
 
-	$( '.rwmb-slider-value' ).each( update );
-	$( document ).on( 'clone', '.rwmb-slider-value', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-slider-value' ).each( transform );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-slider-value', transform );
+} )( jQuery, rwmb );

--- a/js/taxonomy.js
+++ b/js/taxonomy.js
@@ -1,8 +1,10 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb ) {
 	'use strict';
 
-	$( document ).on( 'click', '.rwmb-taxonomy-add-button', function( e ) {
+	function toggleAddInput( e ) {
 		e.preventDefault();
 		this.nextElementSibling.classList.toggle( 'rwmb-hidden' );
-	} );
-} );
+	}
+
+	rwmb.$document.on( 'click', '.rwmb-taxonomy-add-button', toggleAddInput );
+} )( jQuery, rwmb );

--- a/js/time.js
+++ b/js/time.js
@@ -1,11 +1,10 @@
-jQuery( function ( $ ) {
+( function ( $, rwmb, i18n ) {
 	'use strict';
 
 	/**
-	 * Update datetime picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Transform an input into a time picker.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			options = $this.data( 'options' ),
 			$inline = $this.siblings( '.rwmb-datetime-inline' ),
@@ -13,29 +12,35 @@ jQuery( function ( $ ) {
 
 		$this.siblings( '.ui-datepicker-append' ).remove();  // Remove appended text
 
-		if ( $inline.length ) {
-			options.altField = '#' + $this.attr( 'id' );
-			$inline
-				.removeClass( 'hasDatepicker' )
-				.empty()
-				.prop( 'id', '' )
-				.timepicker( options )
-				.timepicker( "setTime", current );
-		}
-		else {
+		if ( ! $inline.length ) {
 			$this.removeClass( 'hasDatepicker' ).timepicker( options );
+			return;
 		}
+
+		options.altField = '#' + $this.attr( 'id' );
+		$inline
+			.removeClass( 'hasDatepicker' )
+			.empty()
+			.prop( 'id', '' )
+			.timepicker( options )
+			.timepicker( 'setTime', current );
 	}
 
 	// Set language if available
-	$.timepicker.setDefaults( $.timepicker.regional[""] );
-	if ( $.timepicker.regional.hasOwnProperty( RWMB_Time.locale ) ) {
-		$.timepicker.setDefaults( $.timepicker.regional[RWMB_Time.locale] );
-	}
-	else if ( $.timepicker.regional.hasOwnProperty( RWMB_Time.localeShort ) ) {
-		$.timepicker.setDefaults( $.timepicker.regional[RWMB_Time.localeShort] );
+	function setTimeI18n() {
+		if ( $.timepicker.regional.hasOwnProperty( i18n.locale ) ) {
+			$.timepicker.setDefaults( $.timepicker.regional[i18n.locale] );
+		} else if ( $.timepicker.regional.hasOwnProperty( i18n.localeShort ) ) {
+			$.timepicker.setDefaults( $.timepicker.regional[i18n.localeShort] );
+		}
 	}
 
-	$( '.rwmb-time' ).each( update );
-	$( '.rwmb-input' ).on( 'clone', '.rwmb-time', update );
-} );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-time' ).each( transform );
+	}
+
+	setTimeI18n();
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-time', transform );
+} )( jQuery, rwmb, RWMB_Time );

--- a/js/video.js
+++ b/js/video.js
@@ -1,7 +1,4 @@
-window.rwmb = window.rwmb || {};
-
-jQuery( function ( $ )
-{
+( function ( $, rwmb ) {
 	'use strict';
 
 	var views = rwmb.views = rwmb.views || {},
@@ -29,18 +26,18 @@ jQuery( function ( $ )
 		}
 	} );
 
-	/**
-	 * Initialize image fields
-	 * @return void
-	 */
-	function initVideoField()
-	{
-		var view = new VideoField( { input: this } );
-		//Remove old then add new
-		$( this ).siblings( 'div.rwmb-media-view' ).remove();
-		$( this ).after( view.el );
+	function initVideoField() {
+		var $this = $( this ),
+			view = new VideoField( { input: this } );
+		$this.siblings( '.rwmb-media-view' ).remove();
+		$this.after( view.el );
 	}
-	$( '.rwmb-video' ).each( initVideoField );
-	$( document )
-		.on( 'clone', '.rwmb-video', initVideoField )
-} );
+
+	function init( e ) {
+		$( e.target ).find( '.rwmb-video' ).each( initVideoField );
+	}
+
+	rwmb.$document
+		.on( 'mb_ready', init )
+		.on( 'clone', '.rwmb-video', initVideoField );
+} )( jQuery, rwmb );

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -1,13 +1,10 @@
-/* global tinymce, quicktags */
-
-jQuery( function ( $ ) {
+( function ( $, wp, window, rwmb ) {
 	'use strict';
 
 	/**
-	 * Update date picker element
-	 * Used for static & dynamic added elements (when clone)
+	 * Transform textarea into wysiwyg editor.
 	 */
-	function update() {
+	function transform() {
 		var $this = $( this ),
 			$wrapper = $this.closest( '.wp-editor-wrap' ),
 			id = $this.attr( 'id' );
@@ -17,30 +14,50 @@ jQuery( function ( $ ) {
 			return;
 		}
 
-		// Get id of the original editor to get its tinyMCE and quick tags settings
-		var originalId = getOriginalId( $this );
-		if ( ! originalId ) {
-			return;
-		}
-
 		// Update the DOM
 		$this.show();
 		updateDom( $wrapper, id );
 
+		// Get id of the original editor to get its tinyMCE and quick tags settings
+		var originalId = getOriginalId( $this ),
+			settings = getEditorSettings( originalId );
+
 		// TinyMCE
-		if ( tinyMCEPreInit.mceInit.hasOwnProperty( originalId ) ) {
-			var settings = tinyMCEPreInit.mceInit[originalId],
-				editor = new tinymce.Editor(id, settings, tinymce.EditorManager);
+		if ( window.tinymce ) {
+			var editor = new tinymce.Editor(id, settings.tinymce, tinymce.EditorManager);
 			editor.render();
 		}
 
 		// Quick tags
-		if ( typeof quicktags === 'function' && tinyMCEPreInit.qtInit.hasOwnProperty( originalId ) ) {
-			var qtSettings = tinyMCEPreInit.qtInit[originalId];
-			qtSettings.id = id;
-			quicktags( qtSettings );
+		if ( window.quicktags ) {
+			settings.quicktags.id = id;
+			quicktags( settings.quicktags );
 			QTags._buttonsInit();
 		}
+	}
+
+	function getEditorSettings( id ) {
+		var settings = getDefaultEditorSettings();
+
+		if ( id && tinyMCEPreInit.mceInit.hasOwnProperty( id ) ) {
+			settings.tinymce = tinyMCEPreInit.mceInit[id];
+		}
+		if ( id && window.quicktags && tinyMCEPreInit.qtInit.hasOwnProperty( id ) ) {
+			settings.quicktags = tinyMCEPreInit.qtInit[id];
+		}
+
+		return settings;
+	}
+
+	function getDefaultEditorSettings() {
+		var settings = wp.editor.getDefaultSettings();
+
+		settings.tinymce.toolbar1 = 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,unlink,wp_more,spellchecker,fullscreen,wp_adv';
+		settings.tinymce.toolbar2 = 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help';
+
+		settings.quicktags.buttons = 'strong,em,link,block,del,ins,img,ul,ol,li,code,more,close';
+
+		return settings;
 	}
 
 	/**
@@ -107,7 +124,12 @@ jQuery( function ( $ ) {
 		} );
 	}
 
-	$( '.rwmb-wysiwyg' ).each( update );
-	$( document ).on( 'clone', '.rwmb-wysiwyg', update );
+	function init( e ) {
+		$( e.target ).find( '.rwmb-wysiwyg' ).each( transform );
+	}
+
 	ensureSave();
-} );
+	rwmb.$document
+		.on( 'mb_blocks_edit', init )
+		.on( 'clone', '.rwmb-wysiwyg', transform );
+} )( jQuery, wp, window, rwmb );

--- a/meta-box.php
+++ b/meta-box.php
@@ -14,6 +14,17 @@
  */
 
 if ( defined( 'ABSPATH' ) && ! defined( 'RWMB_VER' ) ) {
+	register_activation_hook( __FILE__, 'rwmb_check_php_version' );
+
+	/**
+	 * Display notice for old PHP version.
+	 */
+	function rwmb_check_php_version() {
+		if ( version_compare( phpversion(), '5.3', '<' ) ) {
+			die( esc_html__( 'Meta Box requires PHP version 5.3+. Please contact your host to upgrade.', 'meta-box' ) );
+		}
+	}
+
 	require_once dirname( __FILE__ ) . '/inc/loader.php';
 	$rwmb_loader = new RWMB_Loader();
 	$rwmb_loader->init();

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: metabox, rilwis, fitwp, f-j-kaiser, funkatronic, PerWiklander, rua
 Donate link: https://metabox.io/pricing/
 Tags: meta-box, custom fields, custom field, meta, meta-boxes, admin, advanced, custom, edit, field, file, image, magic fields, matrix, more fields, Post, repeater, simple fields, text, textarea, type, cms, fields post
 Requires at least: 4.3
+Requires PHP: 5.3
 Tested up to: 5.2.2
 Stable tag: 4.18.4
 License: GPLv2 or later


### PR DESCRIPTION
Rewrite scripts to use a global event `mb_ready` to trigger actions.

- `mb_ready` is also used for MB Blocks extension which allows to create Gutenberg blocks.
- Create a global `script` for Meta Box to store shared data.
- Update the required PHP version to 5.3.
- Fix styling for Toggle All buttons (for `checkbox_list`) and remove clone button (in Gutenberg block).