### PR TITLE
Update notification

### DIFF
--- a/inc/loader.php
+++ b/inc/loader.php
@@ -111,6 +111,8 @@ class RWMB_Loader {
 		$update_checker->init();
 		$update_settings = new RWMB_Update_Settings( $update_checker );
 		$update_settings->init();
+		$update_notification = new RWMB_Update_Notification( $update_checker );
+		$update_notification->init();
 
 		// Public functions.
 		require_once RWMB_INC_DIR . 'functions.php';

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -107,11 +107,12 @@ class RWMB_Loader {
 		$wpml->init();
 
 		// Update.
-		$update_checker = new RWMB_Update_Checker();
+		$update_option = new RWMB_Update_Option();
+		$update_checker = new RWMB_Update_Checker( $update_option );
 		$update_checker->init();
 		$update_settings = new RWMB_Update_Settings( $update_checker );
 		$update_settings->init();
-		$update_notification = new RWMB_Update_Notification( $update_checker );
+		$update_notification = new RWMB_Update_Notification( $update_checker, $update_option );
 		$update_notification->init();
 
 		// Public functions.

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -110,7 +110,7 @@ class RWMB_Loader {
 		$update_option = new RWMB_Update_Option();
 		$update_checker = new RWMB_Update_Checker( $update_option );
 		$update_checker->init();
-		$update_settings = new RWMB_Update_Settings( $update_checker );
+		$update_settings = new RWMB_Update_Settings( $update_checker, $update_option );
 		$update_settings->init();
 		$update_notification = new RWMB_Update_Notification( $update_checker, $update_option );
 		$update_notification->init();

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -57,6 +57,16 @@ class RWMB_Update_Checker {
 	 * @return bool
 	 */
 	public function has_extensions() {
+		$extensions = $this->get_extensions();
+		return ! empty( $extensions );
+	}
+
+	/**
+	 * Get installed premium extensions.
+	 *
+	 * @return array Array of extension slugs.
+	 */
+	public function get_extensions() {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -85,9 +95,7 @@ class RWMB_Update_Checker {
 		$plugins = get_plugins();
 		$plugins = array_map( 'dirname', array_keys( $plugins ) );
 
-		$installed_extensions = array_intersect( $extensions, $plugins );
-
-		return ! empty( $installed_extensions );
+		return array_intersect( $extensions, $plugins );
 	}
 
 	/**

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * The updater class for Meta Box extensions
+ * The update checker class for Meta Box extensions
  *
  * @package Meta Box
  */
@@ -123,6 +123,10 @@ class RWMB_Update_Checker {
 
 		$plugins = array_filter( $response['data'], array( $this, 'has_update' ) );
 		foreach ( $plugins as $plugin ) {
+			if ( empty( $plugin->package ) ) {
+				$plugin->upgrade_notice = __( 'UPDATE UNAVAILABLE! Please enter a valid license key to enable automatic updates.', 'meta-box' );
+			}
+
 			$data->response[ $plugin->plugin ] = $plugin;
 		}
 

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -19,11 +19,20 @@ class RWMB_Update_Checker {
 	private $api_url = 'https://metabox.io/index.php';
 
 	/**
-	 * The update option.
+	 * The update option object.
 	 *
-	 * @var string
+	 * @var object
 	 */
-	private $option = 'meta_box_updater';
+	private $option;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param object $option  Update option object.
+	 */
+	public function __construct( $option ) {
+		$this->option  = $option;
+	}
 
 	/**
 	 * Add hooks to check plugin updates.
@@ -109,13 +118,7 @@ class RWMB_Update_Checker {
 			$data->response[ $plugin->plugin ] = $plugin;
 		}
 
-		$option            = $this->get_option();
-		$option['plugins'] = array_keys( $plugins );
-		if ( is_multisite() ) {
-			update_site_option( $this->option, $option );
-		} else {
-			update_option( $this->option, $option );
-		}
+		$this->option->set( 'plugins', array_keys( $plugins ) );
 
 		return $data;
 	}
@@ -198,19 +201,6 @@ class RWMB_Update_Checker {
 	 * @return string
 	 */
 	public function get_api_key() {
-		if ( defined( 'META_BOX_KEY' ) ) {
-			return META_BOX_KEY;
-		}
-		$option = $this->get_option();
-		return isset( $option['api_key'] ) ? $option['api_key'] : null;
-	}
-
-	/**
-	 * Get update option.
-	 *
-	 * @return array
-	 */
-	private function get_option() {
-		return is_multisite() ? get_site_option( $this->option, array() ) : get_option( $this->option, array() );
+		return defined( 'META_BOX_KEY' ) ? META_BOX_KEY : $this->option->get( 'api_key' );
 	}
 }

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -154,10 +154,13 @@ class RWMB_Update_Checker {
 	 * @return mixed
 	 */
 	public function request( $args = '' ) {
-		// Add email and API key to the request params.
-		$option = $this->get_option();
-		$args   = wp_parse_args( $args, $option );
-		$args   = array_filter( $args );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'api_key' => $this->get_api_key(),
+			)
+		);
+		$args = array_filter( $args );
 
 		$request = wp_remote_post(
 			$this->api_url,
@@ -187,6 +190,19 @@ class RWMB_Update_Checker {
 		$plugins = get_plugins();
 
 		return isset( $plugins[ $plugin_data->plugin ] ) && version_compare( $plugins[ $plugin_data->plugin ]['Version'], $plugin_data->new_version, '<' );
+	}
+
+	/**
+	 * Get the API key.
+	 *
+	 * @return string
+	 */
+	public function get_api_key() {
+		if ( defined( 'META_BOX_KEY' ) ) {
+			return META_BOX_KEY;
+		}
+		$option = $this->get_option();
+		return isset( $option['api_key'] ) ? $option['api_key'] : null;
 	}
 
 	/**

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -130,8 +130,12 @@ class RWMB_Update_Checker {
 			$data->response[ $plugin->plugin ] = $plugin;
 		}
 
-		$this->option->set( 'status', $response['status'] );
-		$this->option->set( 'plugins', array_keys( $plugins ) );
+		$this->option->update(
+			array(
+				'status'  => $response['status'],
+				'plugins' => array_keys( $plugins ),
+			)
+		);
 
 		return $data;
 	}

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This class notifies users to enter or update license key.
+ *
+ * @package Meta Box
+ */
+
+/**
+ * Meta Box Update Notification class
+ *
+ * @package Meta Box
+ */
+class RWMB_Update_Notification {
+	/**
+	 * Update option.
+	 *
+	 * @var string
+	 */
+	private $option = 'meta_box_updater';
+
+	/**
+	 * Settings page ID.
+	 *
+	 * @var string
+	 */
+	private $page_id = 'meta-box-updater';
+
+	/**
+	 * The update checker object
+	 *
+	 * @var object
+	 */
+	private $checker;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param object $checker Update checker object.
+	 */
+	public function __construct( $checker ) {
+		$this->checker = $checker;
+	}
+
+	/**
+	 * Add hooks to create the settings page and show admin notice.
+	 */
+	public function init() {
+		$admin_notices_hook = is_multisite() ? 'network_admin_notices' : 'admin_notices';
+		add_action( $admin_notices_hook, array( $this, 'notify' ) );
+	}
+
+	/**
+	 * Notify users to enter license key.
+	 */
+	public function notify() {
+		if ( ! $this->checker->has_extensions() ) {
+			return;
+		}
+		$messages  = array(
+			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
+			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
+			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is invalid or expired. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">renew</a> to receive automatic updates and premium support.', 'meta-box-updater' ),
+		);
+		$status    = $this->get_license_status();
+		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
+		if ( isset( $messages[ $status ] ) ) {
+			echo '<div class="notice notice-warning"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/' ) ), '</p></div>';
+		}
+	}
+
+	/**
+	 * Get license status.
+	 */
+	public function get_license_status() {
+		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
+		if ( empty( $option['api_key'] ) ) {
+			return 'no_key';
+		}
+		if ( isset( $option['status'] ) && 'success' !== $option['status'] ) {
+			return 'invalid';
+		}
+		return 'valid';
+	}
+}

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -102,11 +102,11 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( 'You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
+			'no_key'  => __( 'You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
+			'invalid' => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
+			'error'   => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
 			'expired' => __( 'Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a> to get automatic updates and premium support.', 'meta-box' ),
 		);
@@ -132,11 +132,11 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
+			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
+			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
+			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
 			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a>.', 'meta-box' ),
 		);

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -47,6 +47,13 @@ class RWMB_Update_Notification {
 	 * Add hooks to show admin notice.
 	 */
 	public function init() {
+		// Show update message on Plugins page.
+		$extensions = $this->checker->get_extensions();
+		foreach ( $extensions as $extension ) {
+			add_action( "in_plugin_update_message-{$extension}/{$extension}.php", array( $this, 'show_update_message' ), 10, 2 );
+		}
+
+		// Show global update notification.
 		if ( $this->option->get( 'notification_dismissed' ) ) {
 			return;
 		}
@@ -93,9 +100,9 @@ class RWMB_Update_Notification {
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
 			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
 			// Translators: %3$s - URL to the My Account page.
 			'expired' => __( '<b>Warning!</b> Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
 		);
@@ -106,6 +113,41 @@ class RWMB_Update_Notification {
 
 		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
 		echo '<div id="meta-box-notification" class="notice notice-warning is-dismissible"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
+	}
+
+	/**
+	 * Show update message on Plugins page.
+	 *
+	 * @param  array  $plugin_data Plugin data.
+	 * @param  object $response    Available plugin update data.
+	 */
+	public function show_update_message( $plugin_data, $response ) {
+		// Users have an active license.
+		if ( ! empty( $response->package ) ) {
+			return;
+		}
+
+		$messages = array(
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
+			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
+			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
+			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			// Translators: %3$s - URL to the My Account page.
+			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a>.', 'meta-box-updater' ),
+		);
+		$status = $this->get_license_status();
+		if ( ! isset( $messages[ $status ] ) ) {
+			return;
+		}
+
+		$message = __( '<strong>UPDATE UNAVAILABLE!</strong>', 'meta-box' ) . '&nbsp;';
+		$message .= $messages[ $status ];
+
+		$admin_url = is_multisite() ? network_admin_url( 'settings.php?page=meta-box-updater' ) : admin_url( 'admin.php?page=meta-box-updater' );
+
+		echo '<br><span style="width: 26px; height: 20px; display: inline-block;">&nbsp;</span>' . wp_kses_post( sprintf( $message, $admin_url, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) );
 	}
 
 	/**

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -82,6 +82,13 @@ class RWMB_Update_Notification {
 		if ( ! $this->checker->has_extensions() ) {
 			return;
 		}
+
+		// Do not show notification on License page.
+		$screen = get_current_screen();
+		if ( 'meta-box_page_meta-box-updater' === $screen->id ) {
+			return;
+		}
+
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
 			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -19,11 +19,11 @@ class RWMB_Update_Notification {
 	private $option;
 
 	/**
-	 * Settings page ID.
+	 * Settings page URL.
 	 *
 	 * @var string
 	 */
-	private $page_id = 'meta-box-updater';
+	private $settings_page;
 
 	/**
 	 * The update checker object.
@@ -41,6 +41,8 @@ class RWMB_Update_Notification {
 	public function __construct( $checker, $option ) {
 		$this->checker = $checker;
 		$this->option  = $option;
+
+		$this->settings_page = is_multisite() ? network_admin_url( 'settings.php?page=meta-box-updater' ) : admin_url( 'admin.php?page=meta-box-updater' );
 	}
 
 	/**
@@ -50,7 +52,9 @@ class RWMB_Update_Notification {
 		// Show update message on Plugins page.
 		$extensions = $this->checker->get_extensions();
 		foreach ( $extensions as $extension ) {
-			add_action( "in_plugin_update_message-{$extension}/{$extension}.php", array( $this, 'show_update_message' ), 10, 2 );
+			$file = "{$extension}/{$extension}.php";
+			add_action( "in_plugin_update_message-$file", array( $this, 'show_update_message' ), 10, 2 );
+			add_filter( "plugin_action_links_$file", array( $this, 'plugin_links' ), 20 );
 		}
 
 		// Show global update notification.
@@ -98,21 +102,20 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( '<b>Warning!</b> Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			'expired' => __( '<b>Warning!</b> Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a> to get automatic updates and premium support.', 'meta-box' ),
 		);
 		$status   = $this->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {
 			return;
 		}
 
-		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
-		echo '<div id="meta-box-notification" class="notice notice-warning is-dismissible"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
+		echo '<div id="meta-box-notification" class="notice notice-warning is-dismissible"><p>', wp_kses_post( sprintf( $messages[ $status ], $this->settings_page, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
 	}
 
 	/**
@@ -129,25 +132,39 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
+			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a>.', 'meta-box-updater' ),
+			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a>.', 'meta-box' ),
 		);
 		$status = $this->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {
 			return;
 		}
 
-		$message = __( '<strong>UPDATE UNAVAILABLE!</strong>', 'meta-box' ) . '&nbsp;';
-		$message .= $messages[ $status ];
+		echo '<br><span style="width: 26px; height: 20px; display: inline-block;">&nbsp;</span>' . wp_kses_post( sprintf( $messages[ $status ], $this->settings_page, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) );
+	}
 
-		$admin_url = is_multisite() ? network_admin_url( 'settings.php?page=meta-box-updater' ) : admin_url( 'admin.php?page=meta-box-updater' );
+	/**
+	 * Add link for activate or update the license key.
+	 *
+	 * @param array $links Array of plugin links.
+	 *
+	 * @return array
+	 */
+	public function plugin_links( $links ) {
+		$status = $this->get_license_status();
+		if ( 'active' === $status ) {
+			return $links;
+		}
 
-		echo '<br><span style="width: 26px; height: 20px; display: inline-block;">&nbsp;</span>' . wp_kses_post( sprintf( $message, $admin_url, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) );
+		$text    = 'no_key' === $status ? __( 'Activate License', 'meta-box' ) : __( 'Update License', 'meta-box' );
+		$links[] = '<a href="' . esc_url( $this->settings_page ) . '" style="color: #39b54a; font-weight: bold">' . esc_html( $text ) . '</a>';
+
+		return $links;
 	}
 
 	/**

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -79,10 +79,10 @@ class RWMB_Update_Notification {
 	 * Get license status.
 	 */
 	public function get_license_status() {
-		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
-		if ( empty( $option['api_key'] ) ) {
+		if ( ! $this->checker->get_api_key() ) {
 			return 'no_key';
 		}
+		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
 		return isset( $option['status'] ) ? $option['status'] : 'active';
 	}
 }

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -102,20 +102,20 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
+			'no_key'  => __( 'You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
+			'invalid' => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
+			'error'   => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( '<b>Warning!</b> Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a> to get automatic updates and premium support.', 'meta-box' ),
+			'expired' => __( 'Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a> to get automatic updates and premium support.', 'meta-box' ),
 		);
 		$status   = $this->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {
 			return;
 		}
 
-		echo '<div id="meta-box-notification" class="notice notice-warning is-dismissible"><p>', wp_kses_post( sprintf( $messages[ $status ], $this->settings_page, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
+		echo '<div id="meta-box-notification" class="notice notice-warning is-dismissible"><p><span class="dashicons dashicons-warning" style="color: #f56e28"></span> ', wp_kses_post( sprintf( $messages[ $status ], $this->settings_page, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
 	}
 
 	/**
@@ -138,7 +138,7 @@ class RWMB_Update_Notification {
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
 			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a>.', 'meta-box' ),
+			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a>.', 'meta-box' ),
 		);
 		$status = $this->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -56,17 +56,23 @@ class RWMB_Update_Notification {
 		if ( ! $this->checker->has_extensions() ) {
 			return;
 		}
-		$messages  = array(
-			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
+		$messages = array(
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
 			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
-			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
-			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is invalid or expired. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">renew</a> to receive automatic updates and premium support.', 'meta-box-updater' ),
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
+			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
+			'error'   => __( '<b>Warning!</b> Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">get one here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
+			// Translators: %3$s - URL to the My Account page.
+			'expired' => __( '<b>Warning!</b> Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew here</a> to get automatic updates and premium support.', 'meta-box-updater' ),
 		);
-		$status    = $this->get_license_status();
-		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
-		if ( isset( $messages[ $status ] ) ) {
-			echo '<div class="notice notice-warning"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/' ) ), '</p></div>';
+		$status   = $this->get_license_status();
+		if ( ! isset( $messages[ $status ] ) ) {
+			return;
 		}
+
+		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
+		echo '<div class="notice notice-warning"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p></div>';
 	}
 
 	/**
@@ -77,9 +83,6 @@ class RWMB_Update_Notification {
 		if ( empty( $option['api_key'] ) ) {
 			return 'no_key';
 		}
-		if ( isset( $option['status'] ) && 'success' !== $option['status'] ) {
-			return 'invalid';
-		}
-		return 'valid';
+		return isset( $option['status'] ) ? $option['status'] : 'active';
 	}
 }

--- a/inc/update/option.php
+++ b/inc/update/option.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This class handles getting and saving the updater option.
+ *
+ * @package Meta Box
+ */
+
+/**
+ * Meta Box Update Option class
+ *
+ * @package Meta Box
+ */
+class RWMB_Update_Option {
+	/**
+	 * Option name.
+	 *
+	 * @var string
+	 */
+	private $option = 'meta_box_updater';
+
+	/**
+	 * Get an option.
+	 *
+	 * @param string $name    Option name. Pass null to return the option array.
+	 * @param mixed  $default Default value.
+	 */
+	public function get( $name = null, $default = null ) {
+		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
+
+		if ( null === $option ) {
+			return $option;
+		}
+
+		return isset( $option[ $name ] ) ? $option[ $name ] : $default;
+	}
+
+	/**
+	 * Set an option.
+	 *
+	 * @param string $name  Option name.
+	 * @param mixed  $value Option value.
+	 */
+	private function set( $name, $value ) {
+		$option          = $this->get();
+		$option[ $name ] = $value;
+
+		if ( is_multisite() ) {
+			update_site_option( $this->option, $option );
+		} else {
+			update_option( $this->option, $option );
+		}
+	}
+}

--- a/inc/update/option.php
+++ b/inc/update/option.php
@@ -27,7 +27,7 @@ class RWMB_Update_Option {
 	public function get( $name = null, $default = null ) {
 		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
 
-		if ( null === $option ) {
+		if ( null === $name ) {
 			return $option;
 		}
 

--- a/inc/update/option.php
+++ b/inc/update/option.php
@@ -40,10 +40,19 @@ class RWMB_Update_Option {
 	 * @param string $name  Option name.
 	 * @param mixed  $value Option value.
 	 */
-	private function set( $name, $value ) {
+	public function set( $name, $value ) {
 		$option          = $this->get();
 		$option[ $name ] = $value;
 
+		$this->update( $option );
+	}
+
+	/**
+	 * Update the option array.
+	 *
+	 * @param array $option Option value.
+	 */
+	public function update( $option ) {
 		if ( is_multisite() ) {
 			update_site_option( $this->option, $option );
 		} else {

--- a/inc/update/option.php
+++ b/inc/update/option.php
@@ -35,24 +35,14 @@ class RWMB_Update_Option {
 	}
 
 	/**
-	 * Set an option.
-	 *
-	 * @param string $name  Option name.
-	 * @param mixed  $value Option value.
-	 */
-	public function set( $name, $value ) {
-		$option          = $this->get();
-		$option[ $name ] = $value;
-
-		$this->update( $option );
-	}
-
-	/**
 	 * Update the option array.
 	 *
 	 * @param array $option Option value.
 	 */
 	public function update( $option ) {
+		$old_option = $this->get();
+
+		$option = array_merge( $old_option, $option );
 		if ( is_multisite() ) {
 			update_site_option( $this->option, $option );
 		} else {

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -128,16 +128,22 @@ class RWMB_Update_Settings {
 
 		$args           = $option;
 		$args['action'] = 'check_license';
-		$result         = $this->checker->request( $args );
+		$response       = $this->checker->request( $args );
+		$status         = isset( $response['status'] ) ? $response['status'] : 'active';
 
-		if ( false === $result ) {
+		if ( false === $response ) {
+			$message = __( 'Something wrong with the connection to metabox.io. Please try again later.', 'meta-box' );
+			$message = wp_kses_post( $message );
+
+			add_settings_error( '', 'mb-error', $message );
+		} elseif ( 'invalid' === $status ) {
 			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
 			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/', 'https://metabox.io/pricing/' ) );
 
 			add_settings_error( '', 'mb-invalid', $message );
 			$option['status'] = 'invalid';
-		} elseif ( 'expired' === $result ) {
+		} elseif ( 'expired' === $status ) {
 			// Translators: %s - URL to the My Account page.
 			$message = __( 'License expired. Please renew on the <a href="%s" target="_blank">My Account</a> page on metabox.io website.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/' ) );

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -129,30 +129,27 @@ class RWMB_Update_Settings {
 		$args           = $option;
 		$args['action'] = 'check_license';
 		$response       = $this->checker->request( $args );
-		$status         = isset( $response['status'] ) ? $response['status'] : 'active';
+		$status         = isset( $response['status'] ) ? $response['status'] : 'invalid';
 
 		if ( false === $response ) {
-			$message = __( 'Something wrong with the connection to metabox.io. Please try again later.', 'meta-box' );
-			$message = wp_kses_post( $message );
-
-			add_settings_error( '', 'mb-error', $message );
-		} elseif ( 'invalid' === $status ) {
-			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
-			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' );
-			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/', 'https://metabox.io/pricing/' ) );
-
-			add_settings_error( '', 'mb-invalid', $message );
-			$option['status'] = 'invalid';
+			add_settings_error( '', 'mb-error', __( 'Something wrong with the connection to metabox.io. Please try again later.', 'meta-box' ) );
+		} elseif ( 'active' === $status ) {
+			add_settings_error( '', 'mb-success', __( 'Your license is activated.', 'meta-box' ), 'updated' );
 		} elseif ( 'expired' === $status ) {
 			// Translators: %s - URL to the My Account page.
 			$message = __( 'License expired. Please renew on the <a href="%s" target="_blank">My Account</a> page on metabox.io website.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/' ) );
 
 			add_settings_error( '', 'mb-expired', $message );
-			$option['status'] = 'expired';
 		} else {
-			add_settings_error( '', 'mb-success', __( 'Your license is activated.', 'meta-box' ), 'updated' );
+			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
+			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' );
+			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/', 'https://metabox.io/pricing/' ) );
+
+			add_settings_error( '', 'mb-invalid', $message );
 		}
+
+		$option['status'] = $status;
 
 		$admin_notices_hook = is_multisite() ? 'network_admin_notices' : 'admin_notices';
 		add_action( $admin_notices_hook, 'settings_errors' );

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -115,10 +115,9 @@ class RWMB_Update_Settings {
 								'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%2$s" target="_blank">renew your license</a>.', 'meta-box' ),
 							);
 							$status = $this->checker->get_api_key() ? $this->option->get( 'status', 'active' ) : 'no_key';
-							if ( ! isset( $messages[ $status ] ) ) {
-								return;
+							if ( isset( $messages[ $status ] ) ) {
+								echo '<p class="description">', wp_kses_post( sprintf( $messages[ $status ], 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p>';
 							}
-							echo '<p class="description">', wp_kses_post( sprintf( $messages[ $status ], 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p>';
 							?>
 						</td>
 					</tr>

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -130,8 +130,6 @@ class RWMB_Update_Settings {
 		$args['action'] = 'check_license';
 		$result         = $this->checker->request( $args );
 
-		info( $result );
-
 		if ( false === $result ) {
 			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
 			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' );

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -151,7 +151,7 @@ class RWMB_Update_Settings {
 			add_settings_error( '', 'mb-expired', $message );
 			$option['status'] = 'expired';
 		} else {
-			add_settings_error( '', 'mb-success', __( 'Settings saved.', 'meta-box' ), 'updated' );
+			add_settings_error( '', 'mb-success', __( 'Your license is activated.', 'meta-box' ), 'updated' );
 		}
 
 		$admin_notices_hook = is_multisite() ? 'network_admin_notices' : 'admin_notices';

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -85,13 +85,14 @@ class RWMB_Update_Settings {
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Meta Box License', 'meta-box' ); ?></h1>
-			<p><?php esc_html_e( 'Please enter your license key to receive automatic updates for Meta Box extensions.', 'meta-box' ); ?></p>
+			<p><?php esc_html_e( 'Please enter your license key to enable automatic updates for Meta Box extensions.', 'meta-box' ); ?></p>
 			<p>
 				<?php
 				printf(
-					// Translators: %s - URL to MetaBox.io website.
-					wp_kses_post( __( 'To get the license key, please visit the <a href="%s" target="_blank">My Account</a> page on metabox.io website.', 'meta-box' ) ),
-					'https://metabox.io/my-account/'
+					// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
+					wp_kses_post( __( 'To get the license key, visit the <a href="%1$s" target="_blank">My Account</a> page on metabox.io website. If you have not purchased any extension yet, please <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' ) ),
+					'https://metabox.io/my-account/',
+					'https://metabox.io/pricing/'
 				);
 				?>
 			</p>
@@ -102,7 +103,24 @@ class RWMB_Update_Settings {
 				<table class="form-table">
 					<tr>
 						<th scope="row"><?php esc_html_e( 'License Key', 'meta-box' ); ?></th>
-						<td><input required class="regular-text" name="meta_box_updater[api_key]" value="<?php echo esc_attr( $this->option->get( 'api_key' ) ); ?>" type="password"></td>
+						<td>
+							<input required class="regular-text" name="meta_box_updater[api_key]" value="<?php echo esc_attr( $this->option->get( 'api_key' ) ); ?>" type="password">
+							<?php
+							$messages = array(
+								// Translators: %1$s - URL to the pricing page.
+								'invalid' => __( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+								// Translators: %1$s - URL to the pricing page.
+								'error'   => __( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+								// Translators: %2$s - URL to the My Account page.
+								'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%2$s" target="_blank">renew your license</a>.', 'meta-box' ),
+							);
+							$status = $this->checker->get_api_key() ? $this->option->get( 'status', 'active' ) : 'no_key';
+							if ( ! isset( $messages[ $status ] ) ) {
+								return;
+							}
+							echo '<p class="description">', wp_kses_post( sprintf( $messages[ $status ], 'https://metabox.io/pricing/', 'https://metabox.io/my-account/' ) ), '</p>';
+							?>
+						</td>
 					</tr>
 				</table>
 
@@ -143,7 +161,7 @@ class RWMB_Update_Settings {
 			add_settings_error( '', 'mb-expired', $message );
 		} else {
 			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
-			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box' );
+			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/', 'https://metabox.io/pricing/' ) );
 
 			add_settings_error( '', 'mb-invalid', $message );

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -55,16 +55,13 @@ class RWMB_Update_Settings {
 		// Whether to enable Meta Box menu. Priority 1 makes sure it runs before adding Meta Box menu.
 		add_action( 'admin_menu', array( $this, 'enable_menu' ), 1 );
 
-		// Add submenu. Use priority 80 to show it just above the About page (priority = 90).
+		// Add submenu. Priority 90 makes it the last sub-menu item.
 		$admin_menu_hook = is_multisite() ? 'network_admin_menu' : 'admin_menu';
-		add_action( $admin_menu_hook, array( $this, 'add_settings_page' ), 80 );
-
-		$admin_notices_hook = is_multisite() ? 'network_admin_notices' : 'admin_notices';
-		add_action( $admin_notices_hook, array( $this, 'notify' ) );
+		add_action( $admin_menu_hook, array( $this, 'add_settings_page' ), 90 );
 	}
 
 	/**
-	 * Whether to enable Meta Box menu.
+	 * Enable Meta Box menu when a premium extension is installed.
 	 */
 	public function enable_menu() {
 		if ( $this->checker->has_extensions() ) {
@@ -173,39 +170,5 @@ class RWMB_Update_Settings {
 	 */
 	public function show_update_message() {
 		settings_errors();
-	}
-
-	/**
-	 * Notify users to enter license key.
-	 */
-	public function notify() {
-		if ( ! $this->checker->has_extensions() ) {
-			return;
-		}
-		$messages  = array(
-			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
-			'no_key'  => __( '<b>Warning!</b> You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! <a href="%1$s">Enter your license key</a> or <a href="%2$s" target="_blank">get one here</a>.', 'meta-box-updater' ),
-			// Translators: %1$s - URL to Meta Box Updater settings page, %2$s - URL to MetaBox.io website.
-			'invalid' => __( '<b>Warning!</b> Your license key for Meta Box is invalid or expired. Please <a href="%1$s">fix it</a> or <a href="%2$s" target="_blank">renew</a> to receive automatic updates and premium support.', 'meta-box-updater' ),
-		);
-		$status    = $this->get_license_status();
-		$admin_url = is_multisite() ? network_admin_url( "settings.php?page={$this->page_id}" ) : admin_url( "admin.php?page={$this->page_id}" );
-		if ( isset( $messages[ $status ] ) ) {
-			echo '<div class="notice notice-warning"><p>', wp_kses_post( sprintf( $messages[ $status ], $admin_url, 'https://metabox.io/pricing/' ) ), '</p></div>';
-		}
-	}
-
-	/**
-	 * Get license status.
-	 */
-	public function get_license_status() {
-		$option = is_multisite() ? get_site_option( $this->option ) : get_option( $this->option );
-		if ( empty( $option['api_key'] ) ) {
-			return 'no_key';
-		}
-		if ( isset( $option['status'] ) && 'success' !== $option['status'] ) {
-			return 'invalid';
-		}
-		return 'valid';
 	}
 }

--- a/js/notification.js
+++ b/js/notification.js
@@ -1,0 +1,16 @@
+( function( $, document, i18n ) {
+	'use strict';
+
+	function dismissNotification() {
+		$( '#meta-box-notification' ).on( 'click', '.notice-dismiss', function( event ) {
+			event.preventDefault();
+
+			$.post( ajaxurl, {
+				action: 'mb_dismiss_notification',
+				nonce: MBNotification.nonce
+			} );
+		} );
+	}
+
+	$( document ).on( 'ready', dismissNotification );
+} )( jQuery, document, MBNotification );


### PR DESCRIPTION
- Allow to define license key via a constant.
- Make the license notification dismissible.
- Do not show license notification on License page.
- Show update message on Plugins page.
- Add update message on Updates page.
- Add update/activate license link in the plugin action links.
- Add update message on the License page to let users know if the license key is active or not