### PR TITLE
Improve file upload

### DIFF
--- a/inc/clone.php
+++ b/inc/clone.php
@@ -85,16 +85,7 @@ class RWMB_Clone {
 		}
 
 		if ( in_array( $field['type'], array( 'file', 'image' ), true ) ) {
-			// @codingStandardsIgnoreLine
-			$indexes = isset( $_POST[ "_index_{$field['id']}" ] ) ? $_POST[ "_index_{$field['id']}" ] : array();
-			foreach ( $indexes as $key => $index ) {
-				$field['index'] = $index;
-
-				$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : array();
-				$value       = isset( $new[ $key ] ) ? $new[ $key ] : array();
-				$value       = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
-				$new[ $key ] = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
-			}
+			$new = RWMB_File_Field::clone_value( $new, $old, $object_id, $field );
 		} else {
 			foreach ( $new as $key => $value ) {
 				$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : null;

--- a/inc/clone.php
+++ b/inc/clone.php
@@ -40,7 +40,8 @@ class RWMB_Clone {
 			}
 
 			if ( in_array( $sub_field['type'], array( 'file', 'image' ), true ) ) {
-				$sub_field['file_input_name'] = $field['file_input_name'] . "[{$index}]";
+				$sub_field['file_input_name'] = '_file_' . uniqid();
+				$sub_field['file_input_key']  .= "[{$index}]";
 			} elseif ( $field['multiple'] ) {
 				$sub_field['field_name'] .= '[]';
 			}
@@ -84,13 +85,21 @@ class RWMB_Clone {
 		}
 
 		if ( in_array( $field['type'], array( 'file', 'image' ), true ) ) {
-			return RWMB_Field::call( $field, 'value', $new, '', $object_id );
-		}
-
-		foreach ( $new as $key => $value ) {
-			$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : null;
-			$value       = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
-			$new[ $key ] = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
+			// @codingStandardsIgnoreLine
+			$input_keys = isset( $_POST[ "_key_{$field['id']}" ] ) ? $_POST[ "_key_{$field['id']}" ] : array();
+			foreach ( $input_keys as $key => $input_key ) {
+				$old_value               = isset( $old[ $key ] ) ? $old[ $key ] : array();
+				$value                   = isset( $new[ $key ] ) ? $new[ $key ] : array();
+				$field['file_input_key'] = $input_key;
+				$value                   = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
+				$new[ $key ]             = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
+			}
+		} else {
+			foreach ( $new as $key => $value ) {
+				$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : null;
+				$value       = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
+				$new[ $key ] = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
+			}
 		}
 
 		// Remove empty clones.

--- a/inc/clone.php
+++ b/inc/clone.php
@@ -40,7 +40,7 @@ class RWMB_Clone {
 			}
 
 			if ( in_array( $sub_field['type'], array( 'file', 'image' ), true ) ) {
-				$sub_field['file_input_name'] = $field['file_input_name'] . "[{$index}]";
+				$sub_field['field_name'] = $field['field_name'] . "[{$index}]";
 			} elseif ( $field['multiple'] ) {
 				$sub_field['field_name'] .= '[]';
 			}

--- a/inc/clone.php
+++ b/inc/clone.php
@@ -40,7 +40,7 @@ class RWMB_Clone {
 			}
 
 			if ( in_array( $sub_field['type'], array( 'file', 'image' ), true ) ) {
-				$sub_field['field_name'] = $field['field_name'] . "[{$index}]";
+				$sub_field['file_input_name'] = $field['file_input_name'] . "[{$index}]";
 			} elseif ( $field['multiple'] ) {
 				$sub_field['field_name'] .= '[]';
 			}

--- a/inc/clone.php
+++ b/inc/clone.php
@@ -40,8 +40,8 @@ class RWMB_Clone {
 			}
 
 			if ( in_array( $sub_field['type'], array( 'file', 'image' ), true ) ) {
-				$sub_field['file_input_name'] = '_file_' . uniqid();
-				$sub_field['file_input_key']  .= "[{$index}]";
+				$sub_field['input_name'] = '_file_' . uniqid();
+				$sub_field['index_name'] .= "[{$index}]";
 			} elseif ( $field['multiple'] ) {
 				$sub_field['field_name'] .= '[]';
 			}
@@ -86,13 +86,14 @@ class RWMB_Clone {
 
 		if ( in_array( $field['type'], array( 'file', 'image' ), true ) ) {
 			// @codingStandardsIgnoreLine
-			$input_keys = isset( $_POST[ "_key_{$field['id']}" ] ) ? $_POST[ "_key_{$field['id']}" ] : array();
-			foreach ( $input_keys as $key => $input_key ) {
-				$old_value               = isset( $old[ $key ] ) ? $old[ $key ] : array();
-				$value                   = isset( $new[ $key ] ) ? $new[ $key ] : array();
-				$field['file_input_key'] = $input_key;
-				$value                   = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
-				$new[ $key ]             = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
+			$indexes = isset( $_POST[ "_index_{$field['id']}" ] ) ? $_POST[ "_index_{$field['id']}" ] : array();
+			foreach ( $indexes as $key => $index ) {
+				$field['index'] = $index;
+
+				$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : array();
+				$value       = isset( $new[ $key ] ) ? $new[ $key ] : array();
+				$value       = RWMB_Field::call( $field, 'value', $value, $old_value, $object_id );
+				$new[ $key ] = RWMB_Field::filter( 'sanitize', $value, $field, $old_value, $object_id );
 			}
 		} else {
 			foreach ( $new as $key => $value ) {

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -91,7 +91,7 @@ class RWMB_File_Field extends RWMB_Field {
 		// Show form upload.
 		$attributes          = self::get_attributes( $field, $meta );
 		$attributes['type']  = 'file';
-		$attributes['name']  = "{$field['file_input_name']}[]";
+		$attributes['name']  = "{$field['input_name']}[]";
 		$attributes['class'] = 'rwmb-file-input';
 
 		/*
@@ -118,9 +118,9 @@ class RWMB_File_Field extends RWMB_Field {
 		$html .= '</div>';
 
 		$html .= sprintf(
-			'<input type="hidden" class="rwmb-file-input-key" name="%s" value="%s">',
-			$field['file_input_key'],
-			$field['file_input_name']
+			'<input type="hidden" class="rwmb-file-index" name="%s" value="%s">',
+			$field['index_name'],
+			$field['input_name']
 		);
 
 		return $html;
@@ -250,7 +250,7 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return array|mixed
 	 */
 	public static function value( $new, $old, $post_id, $field ) {
-		$input = $field['clone'] ? $field['file_input_key'] : $field['file_input_name'];
+		$input = isset( $field['index'] ) ? $field['index'] : $field['input_name'];
 
 		// @codingStandardsIgnoreLine
 		if ( empty( $input ) || empty( $_FILES[ $input ] ) ) {
@@ -326,9 +326,9 @@ class RWMB_File_Field extends RWMB_Field {
 			)
 		);
 
-		$field['multiple']        = true;
-		$field['file_input_name'] = "_file_{$field['id']}";
-		$field['file_input_key']  = "_key_{$field['id']}";
+		$field['multiple']   = true;
+		$field['input_name'] = "_file_{$field['id']}";
+		$field['index_name'] = "_index_{$field['id']}";
 
 		return $field;
 	}

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -118,9 +118,9 @@ class RWMB_File_Field extends RWMB_Field {
 		$html .= '</div>';
 
 		$html .= sprintf(
-			'<input type="hidden" class="rwmb-file-field-name" name="%s" value="%s">',
-			$field['field_key'],
-			$field['field_input_name']
+			'<input type="hidden" class="rwmb-file-input-key" name="%s" value="%s">',
+			$field['file_input_key'],
+			$field['file_input_name']
 		);
 
 		return $html;
@@ -250,7 +250,7 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return array|mixed
 	 */
 	public static function value( $new, $old, $post_id, $field ) {
-		$key   = $field['field_key'];
+		$key   = $field['file_input_key'];
 		$input = filter_input( INPUT_POST, $key, FILTER_SANITIZE_STRING );
 
 		// @codingStandardsIgnoreLine
@@ -364,8 +364,8 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return array
 	 */
 	public static function normalize( $field ) {
-		$field             = parent::normalize( $field );
-		$field             = wp_parse_args(
+		$field = parent::normalize( $field );
+		$field = wp_parse_args(
 			$field,
 			array(
 				'std'              => array(),
@@ -375,10 +375,10 @@ class RWMB_File_Field extends RWMB_Field {
 				'upload_dir'       => '',
 			)
 		);
-		$field['multiple'] = true;
 
+		$field['multiple']        = true;
 		$field['file_input_name'] = "_file_{$field['id']}";
-		$field['field_key']       = "_key_{$field['id']}";
+		$field['file_input_key']  = "_key_{$field['id']}";
 
 		return $field;
 	}

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -91,7 +91,7 @@ class RWMB_File_Field extends RWMB_Field {
 		// Show form upload.
 		$attributes          = self::get_attributes( $field, $meta );
 		$attributes['type']  = 'file';
-		$attributes['name']  = "{$field['field_name']}[]";
+		$attributes['name']  = "{$field['file_input_name']}[]";
 		$attributes['class'] = 'rwmb-file-input';
 
 		/*
@@ -120,7 +120,7 @@ class RWMB_File_Field extends RWMB_Field {
 		$html .= sprintf(
 			'<input type="hidden" class="rwmb-file-field-name" name="%s" value="%s">',
 			$field['field_key'],
-			$field['field_name']
+			$field['field_input_name']
 		);
 
 		return $html;
@@ -377,8 +377,8 @@ class RWMB_File_Field extends RWMB_Field {
 		);
 		$field['multiple'] = true;
 
-		$field['field_name'] = "_file_{$field['id']}";
-		$field['field_key']  = "_key_{$field['id']}";
+		$field['file_input_name'] = "_file_{$field['id']}";
+		$field['field_key']       = "_key_{$field['id']}";
 
 		return $field;
 	}

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -271,6 +271,37 @@ class RWMB_File_Field extends RWMB_Field {
 	}
 
 	/**
+	 * Get meta values to save for cloneable fields.
+	 *
+	 * @param array $new         The submitted meta value.
+	 * @param array $old         The existing meta value.
+	 * @param int   $object_id   The object ID.
+	 * @param array $field       The field settings.
+	 * @param array $data_source Data source. Either $_POST or custom array. Used in group to get uploaded files.
+	 *
+	 * @return mixed
+	 */
+	public static function clone_value( $new, $old, $object_id, $field, $data_source = null ) {
+		if ( ! $data_source ) {
+			// @codingStandardsIgnoreLine
+			$data_source = $_POST;
+		}
+
+		// @codingStandardsIgnoreLine
+		$indexes = isset( $data_source[ "_index_{$field['id']}" ] ) ? $data_source[ "_index_{$field['id']}" ] : array();
+		foreach ( $indexes as $key => $index ) {
+			$field['index'] = $index;
+
+			$old_value   = isset( $old[ $key ] ) ? $old[ $key ] : array();
+			$value       = isset( $new[ $key ] ) ? $new[ $key ] : array();
+			$value       = self::value( $value, $old_value, $object_id, $field );
+			$new[ $key ] = self::filter( 'sanitize', $value, $field, $old_value, $object_id );
+		}
+
+		return $new;
+	}
+
+	/**
 	 * Handle file upload.
 	 * Consider upload to Media Library or custom folder.
 	 *

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -117,6 +117,12 @@ class RWMB_File_Field extends RWMB_Field {
 		}
 		$html .= '</div>';
 
+		$html .= sprintf(
+			'<input type="hidden" class="rwmb-file-field-name" name="%s" value="%s">',
+			$field['field_key'],
+			$field['field_name']
+		);
+
 		return $html;
 	}
 
@@ -244,10 +250,11 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return array|mixed
 	 */
 	public static function value( $new, $old, $post_id, $field ) {
-		$input = $field['field_name'];
+		$key   = $field['field_key'];
+		$input = filter_input( INPUT_POST, $key, FILTER_SANITIZE_STRING );
 
 		// @codingStandardsIgnoreLine
-		if ( empty( $_FILES[ $input ] ) ) {
+		if ( empty( $input ) || empty( $_FILES[ $input ] ) ) {
 			return $new;
 		}
 
@@ -370,7 +377,8 @@ class RWMB_File_Field extends RWMB_Field {
 		);
 		$field['multiple'] = true;
 
-		$field['field_name'] = '_file_' . $field['id'];
+		$field['field_name'] = "_file_{$field['id']}";
+		$field['field_key']  = "_key_{$field['id']}";
 
 		return $field;
 	}

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -91,7 +91,7 @@ class RWMB_File_Field extends RWMB_Field {
 		// Show form upload.
 		$attributes          = self::get_attributes( $field, $meta );
 		$attributes['type']  = 'file';
-		$attributes['name']  = "{$field['file_input_name']}[]";
+		$attributes['name']  = "{$field['field_name']}[]";
 		$attributes['class'] = 'rwmb-file-input';
 
 		/*
@@ -244,7 +244,7 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return array|mixed
 	 */
 	public static function value( $new, $old, $post_id, $field ) {
-		$input = $field['file_input_name'];
+		$input = $field['field_name'];
 
 		// @codingStandardsIgnoreLine
 		if ( empty( $_FILES[ $input ] ) ) {
@@ -370,7 +370,7 @@ class RWMB_File_Field extends RWMB_Field {
 		);
 		$field['multiple'] = true;
 
-		$field['file_input_name'] = '_file_' . $field['id'];
+		$field['field_name'] = '_file_' . $field['id'];
 
 		return $field;
 	}

--- a/js/file.js
+++ b/js/file.js
@@ -99,9 +99,14 @@
 	// Reset field when cloning.
 	file.resetClone = function() {
 		var $this = $( this ),
-			$clone = $this.closest( '.rwmb-clone' );
+			$clone = $this.closest( '.rwmb-clone' ),
+			$key = $clone.find( '.rwmb-file-input-key' ),
+			inputName = '_file_' + rwmb.uniqid();
+
 		$clone.find( '.rwmb-uploaded' ).remove();
-		$clone.find( '.rwmb-file-input' ).not( ':first' ).remove();
+		$clone.find( '.rwmb-file-input' ).attr( 'name', inputName + '[]' ).not( ':first' ).remove();
+
+		$key.val( inputName );
 	};
 
 	// Set 'required' attribute. 'this' is the wrapper field input.

--- a/js/file.js
+++ b/js/file.js
@@ -100,7 +100,7 @@
 	file.resetClone = function() {
 		var $this = $( this ),
 			$clone = $this.closest( '.rwmb-clone' ),
-			$key = $clone.find( '.rwmb-file-input-key' ),
+			$key = $clone.find( '.rwmb-file-index' ),
 			inputName = '_file_' + rwmb.uniqid();
 
 		$clone.find( '.rwmb-uploaded' ).remove();


### PR DESCRIPTION
Each file upload (clone or non-clone) now has an unique file upload key, allowing to access to `$_FILES` directly, allowing to handle file upload and clone easily in normal fields and in groups.