### PR TITLE
Fill missing image sizes

### DIFF
--- a/inc/fields/image.php
+++ b/inc/fields/image.php
@@ -143,6 +143,18 @@ class RWMB_Image_Field extends RWMB_File_Field {
 		// Do not overwrite width and height by returned value of image meta.
 		$info['width']  = $image[1];
 		$info['height'] = $image[2];
+		
+		foreach (get_intermediate_image_sizes() as $size) {
+		    if (isset($info['sizes'][$size])) {
+			continue;
+		    }
+
+		    $info['sizes'][$size] = [
+			'width'      => $info['width'],
+			'height'     => $info['height'],
+			'source_url' => $info['full_url'],
+		    ];
+		}
 
 		return $info;
 	}


### PR DESCRIPTION
This is just concept. 

Default WP behavior is when original file is smaller than size WP doesn't return any data for it.
For building theme or apps connected to API (Rest API) it is easier to have always data.

But it should be enabled with field option. What do you think about it?