### PR TITLE
Replaced functions to pass code reviews

### DIFF
--- a/inc/about/about.php
+++ b/inc/about/about.php
@@ -63,8 +63,8 @@ class RWMB_About {
 			return;
 		}
 		add_menu_page(
-			__( 'Meta Box', 'meta-box' ),
-			__( 'Meta Box', 'meta-box' ),
+		esc_html__( 'Meta Box', 'meta-box' ),
+		esc_html__( 'Meta Box', 'meta-box' ),
 			'activate_plugins',
 			'meta-box',
 			'__return_null',
@@ -79,8 +79,8 @@ class RWMB_About {
 		$parent_menu = $this->has_menu() ? 'meta-box' : $this->get_parent_menu();
 		$about       = add_submenu_page(
 			$parent_menu,
-			__( 'Welcome to Meta Box', 'meta-box' ),
-			__( 'Dashboard', 'meta-box' ),
+		esc_html__( 'Welcome to Meta Box', 'meta-box' ),
+		esc_html__( 'Dashboard', 'meta-box' ),
 			'activate_plugins',
 			'meta-box',
 			array( $this, 'render' )
@@ -150,7 +150,7 @@ class RWMB_About {
 	 */
 	public function change_footer_text() {
 		// Translators: %1$s - link to review form.
-		echo wp_kses_post( sprintf( __( 'Please rate <strong>Meta Box</strong> <a href="%1$s" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="%1$s" target="_blank">WordPress.org</a> to help us spread the word. Thank you from the Meta Box team!', 'meta-box' ), 'https://wordpress.org/support/view/plugin-reviews/meta-box?filter=5#new-post' ) );
+		echo wp_kses_post( sprintf(esc_html__( 'Please rate <strong>Meta Box</strong> <a href="%1$s" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="%1$s" target="_blank">WordPress.org</a> to help us spread the word. Thank you from the Meta Box team!', 'meta-box' ), 'https://wordpress.org/support/view/plugin-reviews/meta-box?filter=5#new-post' ) );
 	}
 
 	/**

--- a/inc/about/sections/support.php
+++ b/inc/about/sections/support.php
@@ -15,7 +15,7 @@
 			),
 		);
 		// Translators: %s - link to documentation.
-		echo wp_kses( sprintf( __( 'Still need help with Meta Box? We offer excellent support for you. But don\'t forget to check our <a href="%s">documentation</a> first.', 'meta-box' ), 'https://docs.metabox.io?utm_source=WordPress&utm_medium=link&utm_campaign=plugin' ), $allowed_html );
+		echo wp_kses( sprintf(esc_html__( 'Still need help with Meta Box? We offer excellent support for you. But don\'t forget to check our <a href="%s">documentation</a> first.', 'meta-box' ), 'https://docs.metabox.io?utm_source=WordPress&utm_medium=link&utm_campaign=plugin' ), $allowed_html );
 		?>
 	</p>
 	<div class="two">

--- a/inc/about/sections/welcome.php
+++ b/inc/about/sections/welcome.php
@@ -11,7 +11,7 @@
 	$plugin = get_plugin_data( RWMB_DIR . 'meta-box.php', false, false );
 
 	// Translators: %s - Plugin name.
-	echo esc_html( sprintf( __( 'Welcome to %s', 'meta-box' ), $plugin['Name'] ) );
+	echo esc_html( sprintf(esc_html__( 'Welcome to %s', 'meta-box' ), $plugin['Name'] ) );
 	?>
 </h1>
 <div class="about-text"><?php esc_html_e( 'Meta Box is a free Gutenberg and GDPR-compatible WordPress custom fields plugin and framework that makes quick work of customizing a website with—you guessed it—meta boxes and custom fields in WordPress. Follow the instruction below to get started!', 'meta-box' ); ?></div>

--- a/inc/field.php
+++ b/inc/field.php
@@ -351,7 +351,7 @@ abstract class RWMB_Field {
 				'clone'             => false,
 				'max_clone'         => 0,
 				'sort_clone'        => false,
-				'add_button'        => __( '+ Add more', 'meta-box' ),
+				'add_button'        =>esc_html__( '+ Add more', 'meta-box' ),
 				'clone_default'     => false,
 				'clone_as_multiple' => false,
 

--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -20,7 +20,7 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 			'rwmb-autocomplete',
 			'RWMB_Autocomplete',
 			array(
-				'delete' => __( 'Delete', 'meta-box' ),
+				'delete' =>esc_html__( 'Delete', 'meta-box' ),
 			)
 		);
 	}

--- a/inc/fields/background.php
+++ b/inc/fields/background.php
@@ -61,7 +61,7 @@ class RWMB_Background_Field extends RWMB_Field {
 				'type'        => 'file_input',
 				'id'          => "{$field['id']}_image",
 				'field_name'  => "{$field['field_name']}[image]",
-				'placeholder' => __( 'Background Image', 'meta-box' ),
+				'placeholder' =>esc_html__( 'Background Image', 'meta-box' ),
 			)
 		);
 		$output .= RWMB_File_Input_Field::html( $meta['image'], $image );

--- a/inc/fields/button.php
+++ b/inc/fields/button.php
@@ -31,7 +31,7 @@ class RWMB_Button_Field extends RWMB_Field {
 		$field = wp_parse_args(
 			$field,
 			array(
-				'std' => __( 'Click me', 'meta-box' ),
+				'std' =>esc_html__( 'Click me', 'meta-box' ),
 			)
 		);
 		$field = parent::normalize( $field );

--- a/inc/fields/checkbox.php
+++ b/inc/fields/checkbox.php
@@ -50,6 +50,6 @@ class RWMB_Checkbox_Field extends RWMB_Input_Field {
 	 * @return string
 	 */
 	public static function format_single_value( $field, $value, $args, $post_id ) {
-		return $value ? __( 'Yes', 'meta-box' ) : __( 'No', 'meta-box' );
+		return $value ?esc_html__( 'Yes', 'meta-box' ) :esc_html__( 'No', 'meta-box' );
 	}
 }

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -21,9 +21,9 @@ class RWMB_File_Field extends RWMB_Field {
 			'rwmbFile',
 			array(
 				// Translators: %d is the number of files in singular form.
-				'maxFileUploadsSingle' => __( 'You may only upload maximum %d file', 'meta-box' ),
+				'maxFileUploadsSingle' =>esc_html__( 'You may only upload maximum %d file', 'meta-box' ),
 				// Translators: %d is the number of files in plural form.
-				'maxFileUploadsPlural' => __( 'You may only upload maximum %d files', 'meta-box' ),
+				'maxFileUploadsPlural' =>esc_html__( 'You may only upload maximum %d files', 'meta-box' ),
 			)
 		);
 	}
@@ -60,7 +60,7 @@ class RWMB_File_Field extends RWMB_Field {
 		$field_value = self::raw_meta( $object_id, $field );
 		$field_value = $field['clone'] ? call_user_func_array( 'array_merge', $field_value ) : $field_value;
 		if ( ! in_array( $attachment, $field_value ) ) {
-			wp_send_json_error( __( 'Error: Invalid file', 'meta-box' ) );
+			wp_send_json_error(esc_html__( 'Error: Invalid file', 'meta-box' ) );
 		}
 
 		// Delete the file.
@@ -74,7 +74,7 @@ class RWMB_File_Field extends RWMB_Field {
 		if ( $result ) {
 			wp_send_json_success();
 		}
-		wp_send_json_error( __( 'Error: Cannot delete file', 'meta-box' ) );
+		wp_send_json_error(esc_html__( 'Error: Cannot delete file', 'meta-box' ) );
 	}
 
 	/**

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -87,7 +87,7 @@ class RWMB_File_Field extends RWMB_Field {
 	 */
 	public static function html( $meta, $field ) {
 		$meta      = array_filter( (array) $meta );
-		$i18n_more = apply_filters( 'rwmb_file_add_string', _x( '+ Add new file', 'file upload', 'meta-box' ), $field );
+		$i18n_more = apply_filters( 'rwmb_file_add_string',esc_html_x( '+ Add new file', 'file upload', 'meta-box' ), $field );
 		$html      = self::get_uploaded_files( $meta, $field );
 
 		// Show form upload.
@@ -168,8 +168,8 @@ class RWMB_File_Field extends RWMB_Field {
 	 * @return string
 	 */
 	protected static function file_html( $file, $index, $field ) {
-		$i18n_delete = apply_filters( 'rwmb_file_delete_string', _x( 'Delete', 'file upload', 'meta-box' ) );
-		$i18n_edit   = apply_filters( 'rwmb_file_edit_string', _x( 'Edit', 'file upload', 'meta-box' ) );
+		$i18n_delete = apply_filters( 'rwmb_file_delete_string',esc_html_x( 'Delete', 'file upload', 'meta-box' ) );
+		$i18n_edit   = apply_filters( 'rwmb_file_edit_string',esc_html_x( 'Edit', 'file upload', 'meta-box' ) );
 		$attributes  = self::get_attributes( $field, $file );
 
 		if ( ! $file ) {

--- a/inc/fields/input-list.php
+++ b/inc/fields/input-list.php
@@ -89,7 +89,7 @@ class RWMB_Input_List_Field extends RWMB_Choice_Field {
 	 */
 	public static function get_select_all_html( $field ) {
 		if ( $field['multiple'] && $field['select_all_none'] ) {
-			return sprintf( '<p class="rwmb-toggle-all-wrapper"><button class="rwmb-input-list-select-all-none button" data-name="%s">%s</button></p>', $field['id'], __( 'Toggle All', 'meta-box' ) );
+			return sprintf( '<p class="rwmb-toggle-all-wrapper"><button class="rwmb-input-list-select-all-none button" data-name="%s">%s</button></p>', $field['id'],esc_html__( 'Toggle All', 'meta-box' ) );
 		}
 		return '';
 	}

--- a/inc/fields/key-value.php
+++ b/inc/fields/key-value.php
@@ -132,8 +132,8 @@ class RWMB_Key_Value_Field extends RWMB_Text_Field {
 		$field['placeholder']        = wp_parse_args(
 			(array) $field['placeholder'],
 			array(
-				'key'   => __( 'Key', 'meta-box' ),
-				'value' => __( 'Value', 'meta-box' ),
+				'key'   =>esc_html__( 'Key', 'meta-box' ),
+				'value' =>esc_html__( 'Value', 'meta-box' ),
 			)
 		);
 		return $field;

--- a/inc/fields/map.php
+++ b/inc/fields/map.php
@@ -52,7 +52,7 @@ class RWMB_Map_Field extends RWMB_Field {
 			'rwmb-map',
 			'RWMB_Map',
 			array(
-				'no_results_string' => __( 'No results found', 'meta-box' ),
+				'no_results_string' =>esc_html__( 'No results found', 'meta-box' ),
 			)
 		);
 	}

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -24,18 +24,18 @@ class RWMB_Media_Field extends RWMB_File_Field {
 			'rwmb-media',
 			'i18nRwmbMedia',
 			array(
-				'add'                => apply_filters( 'rwmb_media_add_string', _x( '+ Add Media', 'media', 'meta-box' ) ),
-				'single'             => apply_filters( 'rwmb_media_single_files_string', _x( ' file', 'media', 'meta-box' ) ),
-				'multiple'           => apply_filters( 'rwmb_media_multiple_files_string', _x( ' files', 'media', 'meta-box' ) ),
-				'remove'             => apply_filters( 'rwmb_media_remove_string', _x( 'Remove', 'media', 'meta-box' ) ),
-				'edit'               => apply_filters( 'rwmb_media_edit_string', _x( 'Edit', 'media', 'meta-box' ) ),
-				'view'               => apply_filters( 'rwmb_media_view_string', _x( 'View', 'media', 'meta-box' ) ),
-				'noTitle'            => _x( 'No Title', 'media', 'meta-box' ),
+				'add'                => apply_filters( 'rwmb_media_add_string',esc_html_x( '+ Add Media', 'media', 'meta-box' ) ),
+				'single'             => apply_filters( 'rwmb_media_single_files_string',esc_html_x( ' file', 'media', 'meta-box' ) ),
+				'multiple'           => apply_filters( 'rwmb_media_multiple_files_string',esc_html_x( ' files', 'media', 'meta-box' ) ),
+				'remove'             => apply_filters( 'rwmb_media_remove_string',esc_html_x( 'Remove', 'media', 'meta-box' ) ),
+				'edit'               => apply_filters( 'rwmb_media_edit_string',esc_html_x( 'Edit', 'media', 'meta-box' ) ),
+				'view'               => apply_filters( 'rwmb_media_view_string',esc_html_x( 'View', 'media', 'meta-box' ) ),
+				'noTitle'            =>esc_html_x( 'No Title', 'media', 'meta-box' ),
 				'loadingUrl'         => admin_url( 'images/spinner.gif' ),
 				'extensions'         => self::get_mime_extensions(),
-				'select'             => apply_filters( 'rwmb_media_select_string', _x( 'Select Files', 'media', 'meta-box' ) ),
-				'or'                 => apply_filters( 'rwmb_media_or_string', _x( 'or', 'media', 'meta-box' ) ),
-				'uploadInstructions' => apply_filters( 'rwmb_media_upload_instructions_string', _x( 'Drop files here to upload', 'media', 'meta-box' ) ),
+				'select'             => apply_filters( 'rwmb_media_select_string',esc_html_x( 'Select Files', 'media', 'meta-box' ) ),
+				'or'                 => apply_filters( 'rwmb_media_or_string',esc_html_x( 'or', 'media', 'meta-box' ) ),
+				'uploadInstructions' => apply_filters( 'rwmb_media_upload_instructions_string',esc_html_x( 'Drop files here to upload', 'media', 'meta-box' ) ),
 			)
 		);
 	}

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -164,7 +164,7 @@ class RWMB_Media_Field extends RWMB_File_Field {
 			}
 		}
 		$attachments                    = array_values( $attachments );
-		$attributes['data-attachments'] = json_encode( $attachments );
+		$attributes['data-attachments'] = wp_json_encode( $attachments );
 
 		return $attributes;
 	}

--- a/inc/fields/oembed.php
+++ b/inc/fields/oembed.php
@@ -21,7 +21,7 @@ class RWMB_OEmbed_Field extends RWMB_Text_Field {
 		$field               = wp_parse_args(
 			$field,
 			array(
-				'not_available_string' => __( 'Embed HTML not available.', 'meta-box' ),
+				'not_available_string' =>esc_html__( 'Embed HTML not available.', 'meta-box' ),
 			)
 		);
 		$field['attributes'] = wp_parse_args(

--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -25,7 +25,7 @@ class RWMB_OSM_Field extends RWMB_Field {
 			'rwmb-osm',
 			'RWMB_Osm',
 			array(
-				'no_results_string' => __( 'No results found', 'meta-box' ),
+				'no_results_string' =>esc_html__( 'No results found', 'meta-box' ),
 			)
 		);
 	}

--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -77,13 +77,13 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 		 * - If multiple post types: show 'Select a post'.
 		 * - If single post type: show 'Select a %post_type_name%'.
 		 */
-		$placeholder = __( 'Select a post', 'meta-box' );
+		$placeholder =esc_html__( 'Select a post', 'meta-box' );
 		if ( 1 === count( $field['post_type'] ) ) {
 			$post_type        = reset( $field['post_type'] );
 			$post_type_object = get_post_type_object( $post_type );
 			if ( ! empty( $post_type_object ) ) {
 				// Translators: %s is the taxonomy singular label.
-				$placeholder = sprintf( __( 'Select a %s', 'meta-box' ), strtolower( $post_type_object->labels->singular_name ) );
+				$placeholder = sprintf(esc_html__( 'Select a %s', 'meta-box' ), strtolower( $post_type_object->labels->singular_name ) );
 			}
 		}
 		$field = wp_parse_args(

--- a/inc/fields/select-advanced.php
+++ b/inc/fields/select-advanced.php
@@ -44,7 +44,7 @@ class RWMB_Select_Advanced_Field extends RWMB_Select_Field {
 			$field,
 			array(
 				'js_options'  => array(),
-				'placeholder' => __( 'Select an item', 'meta-box' ),
+				'placeholder' =>esc_html__( 'Select an item', 'meta-box' ),
 			)
 		);
 

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -89,7 +89,7 @@ class RWMB_Select_Field extends RWMB_Choice_Field {
 	 */
 	public static function get_select_all_html( $field ) {
 		if ( $field['multiple'] && $field['select_all_none'] ) {
-			return '<div class="rwmb-select-all-none">' . __( 'Select', 'meta-box' ) . ': <a data-type="all" href="#">' . __( 'All', 'meta-box' ) . '</a> | <a data-type="none" href="#">' . __( 'None', 'meta-box' ) . '</a></div>';
+			return '<div class="rwmb-select-all-none">' .esc_html__( 'Select', 'meta-box' ) . ': <a data-type="all" href="#">' .esc_html__( 'All', 'meta-box' ) . '</a> | <a data-type="none" href="#">' .esc_html__( 'None', 'meta-box' ) . '</a></div>';
 		}
 		return '';
 	}

--- a/inc/fields/sidebar.php
+++ b/inc/fields/sidebar.php
@@ -20,7 +20,7 @@ class RWMB_Sidebar_Field extends RWMB_Object_Choice_Field {
 		$field = wp_parse_args(
 			$field,
 			array(
-				'placeholder' => __( 'Select a sidebar', 'meta-box' ),
+				'placeholder' =>esc_html__( 'Select a sidebar', 'meta-box' ),
 			)
 		);
 

--- a/inc/fields/switch.php
+++ b/inc/fields/switch.php
@@ -90,8 +90,8 @@ class RWMB_Switch_Field extends RWMB_Input_Field {
 	 * @return string
 	 */
 	public static function format_single_value( $field, $value, $args, $post_id ) {
-		$on  = $field['on_label'] ? $field['on_label'] : __( 'On', 'meta-box' );
-		$off = $field['off_label'] ? $field['on_label'] : __( 'Off', 'meta-box' );
+		$on  = $field['on_label'] ? $field['on_label'] :esc_html__( 'On', 'meta-box' );
+		$off = $field['off_label'] ? $field['on_label'] :esc_html__( 'Off', 'meta-box' );
 		return $value ? $on : $off;
 	}
 }

--- a/inc/fields/taxonomy.php
+++ b/inc/fields/taxonomy.php
@@ -91,11 +91,11 @@ class RWMB_Taxonomy_Field extends RWMB_Object_Choice_Field {
 		 * - If multiple taxonomies: show 'Select a term'.
 		 * - If single taxonomy: show 'Select a %taxonomy_name%'.
 		 */
-		$placeholder   = __( 'Select a term', 'meta-box' );
+		$placeholder   =esc_html__( 'Select a term', 'meta-box' );
 		$taxonomy_name = self::get_taxonomy_singular_name( $field );
 		if ( $taxonomy_name ) {
 			// Translators: %s is the taxonomy singular label.
-			$placeholder = sprintf( __( 'Select a %s', 'meta-box' ), strtolower( $taxonomy_name ) );
+			$placeholder = sprintf(esc_html__( 'Select a %s', 'meta-box' ), strtolower( $taxonomy_name ) );
 		}
 		$field = wp_parse_args(
 			$field,

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -81,7 +81,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		$field = wp_parse_args(
 			$field,
 			array(
-				'placeholder'   => __( 'Select an user', 'meta-box' ),
+				'placeholder'   =>esc_html__( 'Select an user', 'meta-box' ),
 				'query_args'    => array(),
 				'display_field' => 'display_name',
 			)

--- a/inc/update/checker.php
+++ b/inc/update/checker.php
@@ -131,7 +131,7 @@ class RWMB_Update_Checker {
 		$plugins = array_filter( $response['data'], array( $this, 'has_update' ) );
 		foreach ( $plugins as $plugin ) {
 			if ( empty( $plugin->package ) ) {
-				$plugin->upgrade_notice = __( 'UPDATE UNAVAILABLE! Please enter a valid license key to enable automatic updates.', 'meta-box' );
+				$plugin->upgrade_notice =esc_html__( 'UPDATE UNAVAILABLE! Please enter a valid license key to enable automatic updates.', 'meta-box' );
 			}
 
 			$data->response[ $plugin->plugin ] = $plugin;

--- a/inc/update/notification.php
+++ b/inc/update/notification.php
@@ -109,13 +109,13 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( 'You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+			'no_key'  =>esc_html__( 'You have not set your Meta Box license key yet, which means you are missing out on automatic updates and support! Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
+			'invalid' =>esc_html__( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
+			'error'   =>esc_html__( 'Your license key for Meta Box is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one</a> to enable automatic updates.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( 'Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a> to get automatic updates and premium support.', 'meta-box' ),
+			'expired' =>esc_html__( 'Your license key for Meta Box is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a> to get automatic updates and premium support.', 'meta-box' ),
 		);
 		$status   = $this->option->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {
@@ -139,13 +139,13 @@ class RWMB_Update_Notification {
 
 		$messages = array(
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'no_key'  => __( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+			'no_key'  =>esc_html__( 'Please <a href="%1$s">enter your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'invalid' => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+			'invalid' =>esc_html__( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %1$s - URL to the settings page, %2$s - URL to the pricing page.
-			'error'   => __( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+			'error'   =>esc_html__( 'Your license key is <b>invalid</b>. Please <a href="%1$s">update your license key</a> or <a href="%2$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 			// Translators: %3$s - URL to the My Account page.
-			'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a>.', 'meta-box' ),
+			'expired' =>esc_html__( 'Your license key is <b>expired</b>. Please <a href="%3$s" target="_blank">renew your license</a>.', 'meta-box' ),
 		);
 		$status   = $this->option->get_license_status();
 		if ( ! isset( $messages[ $status ] ) ) {
@@ -168,7 +168,7 @@ class RWMB_Update_Notification {
 			return $links;
 		}
 
-		$text    = 'no_key' === $status ? __( 'Activate License', 'meta-box' ) : __( 'Update License', 'meta-box' );
+		$text    = 'no_key' === $status ?esc_html__( 'Activate License', 'meta-box' ) :esc_html__( 'Update License', 'meta-box' );
 		$links[] = '<a href="' . esc_url( $this->settings_page ) . '" class="rwmb-activate-license" style="color: #39b54a; font-weight: bold">' . esc_html( $text ) . '</a>';
 
 		return $links;

--- a/inc/update/settings.php
+++ b/inc/update/settings.php
@@ -93,7 +93,7 @@ class RWMB_Update_Settings {
 				<?php
 				printf(
 					// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
-					wp_kses_post( __( 'To get the license key, visit the <a href="%1$s" target="_blank">My Account</a> page on metabox.io website. If you have not purchased any extension yet, please <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' ) ),
+					wp_kses_post(esc_html__( 'To get the license key, visit the <a href="%1$s" target="_blank">My Account</a> page on metabox.io website. If you have not purchased any extension yet, please <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' ) ),
 					'https://metabox.io/my-account/',
 					'https://metabox.io/pricing/'
 				);
@@ -110,12 +110,12 @@ class RWMB_Update_Settings {
 							<?php
 							$messages = array(
 								// Translators: %1$s - URL to the pricing page.
-								'invalid' => __( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+								'invalid' =>esc_html__( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 								// Translators: %1$s - URL to the pricing page.
-								'error'   => __( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
+								'error'   =>esc_html__( 'Your license key is <b>invalid</b>. Please update your license key or <a href="%1$s" target="_blank">get a new one here</a>.', 'meta-box' ),
 								// Translators: %2$s - URL to the My Account page.
-								'expired' => __( 'Your license key is <b>expired</b>. Please <a href="%2$s" target="_blank">renew your license</a>.', 'meta-box' ),
-								'active'  => __( 'Your license key is <b>active</b>.', 'meta-box' ),
+								'expired' =>esc_html__( 'Your license key is <b>expired</b>. Please <a href="%2$s" target="_blank">renew your license</a>.', 'meta-box' ),
+								'active'  =>esc_html__( 'Your license key is <b>active</b>.', 'meta-box' ),
 							);
 							$status   = $this->option->get_license_status();
 							$api_key  = in_array( $status, array( 'expired', 'active' ), true ) ? '********************************' : $this->option->get( 'api_key' );
@@ -128,7 +128,7 @@ class RWMB_Update_Settings {
 					</tr>
 				</table>
 
-				<?php submit_button( __( 'Save Changes', 'meta-box' ) ); ?>
+				<?php submit_button(esc_html__( 'Save Changes', 'meta-box' ) ); ?>
 			</form>
 		</div>
 		<?php
@@ -154,18 +154,18 @@ class RWMB_Update_Settings {
 		$status         = isset( $response['status'] ) ? $response['status'] : 'invalid';
 
 		if ( false === $response ) {
-			add_settings_error( '', 'mb-error', __( 'Something wrong with the connection to metabox.io. Please try again later.', 'meta-box' ) );
+			add_settings_error( '', 'mb-error',esc_html__( 'Something wrong with the connection to metabox.io. Please try again later.', 'meta-box' ) );
 		} elseif ( 'active' === $status ) {
-			add_settings_error( '', 'mb-success', __( 'Your license is activated.', 'meta-box' ), 'updated' );
+			add_settings_error( '', 'mb-success',esc_html__( 'Your license is activated.', 'meta-box' ), 'updated' );
 		} elseif ( 'expired' === $status ) {
 			// Translators: %s - URL to the My Account page.
-			$message = __( 'License expired. Please renew on the <a href="%s" target="_blank">My Account</a> page on metabox.io website.', 'meta-box' );
+			$message =esc_html__( 'License expired. Please renew on the <a href="%s" target="_blank">My Account</a> page on metabox.io website.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/' ) );
 
 			add_settings_error( '', 'mb-expired', $message );
 		} else {
 			// Translators: %1$s - URL to the My Account page, %2$s - URL to the pricing page.
-			$message = __( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' );
+			$message =esc_html__( 'Invalid license. Please <a href="%1$s" target="_blank">check again</a> or <a href="%2$s" target="_blank">get a new license here</a>.', 'meta-box' );
 			$message = wp_kses_post( sprintf( $message, 'https://metabox.io/my-account/', 'https://metabox.io/pricing/' ) );
 
 			add_settings_error( '', 'mb-invalid', $message );

--- a/meta-box.php
+++ b/meta-box.php
@@ -21,7 +21,7 @@ if ( defined( 'ABSPATH' ) && ! defined( 'RWMB_VER' ) ) {
 	 */
 	function rwmb_check_php_version() {
 		if ( version_compare( phpversion(), '5.3', '<' ) ) {
-			die( esc_html__( 'Meta Box requires PHP version 5.3+. Please contact your host to upgrade.', 'meta-box' ) );
+			wp_die( esc_html__( 'Meta Box requires PHP version 5.3+. Please contact your host to upgrade.', 'meta-box' ) );
 		}
 	}
 

--- a/tests/005-rwmb-the-value.php
+++ b/tests/005-rwmb-the-value.php
@@ -9,35 +9,35 @@ add_filter(
 		global $test;
 		$prefix = '';
 		$test   = array(
-			'title'  => __( 'Test helper functions', 'your-prefix' ),
+			'title'  =>esc_html__( 'Test helper functions', 'your-prefix' ),
 			'fields' => array(
 				array(
 					'id'   => 'checkbox',
-					'name' => __( 'Checkbox', 'your-prefix' ),
+					'name' =>esc_html__( 'Checkbox', 'your-prefix' ),
 					'type' => 'checkbox',
 				),
 				array(
 					'id'   => 'color',
-					'name' => __( 'Color', 'your-prefix' ),
+					'name' =>esc_html__( 'Color', 'your-prefix' ),
 					'type' => 'color',
 				),
 				array(
 					'id'    => 'color2',
-					'name'  => __( 'Color clone', 'your-prefix' ),
+					'name'  =>esc_html__( 'Color clone', 'your-prefix' ),
 					'type'  => 'color',
 					'clone' => true,
 				),
 
 				// Object choice
 				array(
-					'name'       => __( 'Post', 'your-prefix' ),
+					'name'       =>esc_html__( 'Post', 'your-prefix' ),
 					'id'         => 'post',
 					'type'       => 'post',
 					'post_type'  => 'post',
 					'field_type' => 'select_advanced',
 				),
 				array(
-					'name'       => __( 'Post Multiple', 'your-prefix' ),
+					'name'       =>esc_html__( 'Post Multiple', 'your-prefix' ),
 					'id'         => 'post2',
 					'type'       => 'post',
 					'multiple'   => true,
@@ -45,7 +45,7 @@ add_filter(
 					'field_type' => 'select_advanced',
 				),
 				array(
-					'name'       => __( 'Post Clone', 'your-prefix' ),
+					'name'       =>esc_html__( 'Post Clone', 'your-prefix' ),
 					'id'         => 'post3',
 					'type'       => 'post',
 					'clone'      => true,
@@ -53,7 +53,7 @@ add_filter(
 					'field_type' => 'select_advanced',
 				),
 				array(
-					'name'       => __( 'Post Clone and Multiple', 'your-prefix' ),
+					'name'       =>esc_html__( 'Post Clone and Multiple', 'your-prefix' ),
 					'id'         => 'post4',
 					'type'       => 'post',
 					'clone'      => true,
@@ -85,34 +85,34 @@ add_filter(
 
 				// Radio
 				array(
-					'name'    => __( 'Radio', 'your-prefix' ),
+					'name'    =>esc_html__( 'Radio', 'your-prefix' ),
 					'id'      => 'radio',
 					'type'    => 'radio',
 					'options' => array(
-						'value1' => __( 'Label1', 'your-prefix' ),
-						'value2' => __( 'Label2', 'your-prefix' ),
+						'value1' =>esc_html__( 'Label1', 'your-prefix' ),
+						'value2' =>esc_html__( 'Label2', 'your-prefix' ),
 					),
 				),
 				array(
-					'name'    => __( 'Radio clone', 'your-prefix' ),
+					'name'    =>esc_html__( 'Radio clone', 'your-prefix' ),
 					'id'      => 'radio2',
 					'type'    => 'radio',
 					'clone'   => true,
 					'options' => array(
-						'value1' => __( 'Label1', 'your-prefix' ),
-						'value2' => __( 'Label2', 'your-prefix' ),
+						'value1' =>esc_html__( 'Label1', 'your-prefix' ),
+						'value2' =>esc_html__( 'Label2', 'your-prefix' ),
 					),
 				),
 
 				// oembed
 				array(
 					'id'   => 'oembed',
-					'name' => __( 'oEmbed', 'your-prefix' ),
+					'name' =>esc_html__( 'oEmbed', 'your-prefix' ),
 					'type' => 'oembed',
 				),
 				array(
 					'id'    => 'oembed2',
-					'name'  => __( 'oEmbed clone', 'your-prefix' ),
+					'name'  =>esc_html__( 'oEmbed clone', 'your-prefix' ),
 					'type'  => 'oembed',
 					'clone' => true,
 				),
@@ -120,7 +120,7 @@ add_filter(
 				// Image select
 				array(
 					'id'      => 'image_select',
-					'name'    => __( 'Image Select', 'your-prefix' ),
+					'name'    =>esc_html__( 'Image Select', 'your-prefix' ),
 					'type'    => 'image_select',
 					'options' => array(
 						'left'  => 'http://placehold.it/90x90&text=Left',
@@ -130,7 +130,7 @@ add_filter(
 				),
 				array(
 					'id'       => 'image_select2',
-					'name'     => __( 'Image Select Multiple', 'your-prefix' ),
+					'name'     =>esc_html__( 'Image Select Multiple', 'your-prefix' ),
 					'type'     => 'image_select',
 					'options'  => array(
 						'left'  => 'http://placehold.it/90x90&text=Left',
@@ -141,7 +141,7 @@ add_filter(
 				),
 				array(
 					'id'      => 'image_select3',
-					'name'    => __( 'Image Select Clone', 'your-prefix' ),
+					'name'    =>esc_html__( 'Image Select Clone', 'your-prefix' ),
 					'type'    => 'image_select',
 					'options' => array(
 						'left'  => 'http://placehold.it/90x90&text=Left',
@@ -165,32 +165,32 @@ add_filter(
 				// Key-value
 				array(
 					'id'   => 'key_value',
-					'name' => __( 'Key Value', 'your-prefix' ),
+					'name' =>esc_html__( 'Key Value', 'your-prefix' ),
 					'type' => 'key_value',
-					'desc' => __( 'Add more additional info below:', 'your-prefix' ),
+					'desc' =>esc_html__( 'Add more additional info below:', 'your-prefix' ),
 				),
 
 				// Fieldset text
 				array(
 					'id'      => 'fieldset_text',
-					'name'    => __( 'Fieldset Text', 'your-prefix' ),
+					'name'    =>esc_html__( 'Fieldset Text', 'your-prefix' ),
 					'type'    => 'fieldset_text',
-					'desc'    => __( 'Please enter following details:', 'your-prefix' ),
+					'desc'    =>esc_html__( 'Please enter following details:', 'your-prefix' ),
 					'options' => array(
-						'name'    => __( 'Name', 'your-prefix' ),
-						'address' => __( 'Address', 'your-prefix' ),
-						'email'   => __( 'Email', 'your-prefix' ),
+						'name'    =>esc_html__( 'Name', 'your-prefix' ),
+						'address' =>esc_html__( 'Address', 'your-prefix' ),
+						'email'   =>esc_html__( 'Email', 'your-prefix' ),
 					),
 				),
 				array(
 					'id'      => 'fieldset_text2',
-					'name'    => __( 'Fieldset Text Clone', 'your-prefix' ),
+					'name'    =>esc_html__( 'Fieldset Text Clone', 'your-prefix' ),
 					'type'    => 'fieldset_text',
-					'desc'    => __( 'Please enter following details:', 'your-prefix' ),
+					'desc'    =>esc_html__( 'Please enter following details:', 'your-prefix' ),
 					'options' => array(
-						'name'    => __( 'Name', 'your-prefix' ),
-						'address' => __( 'Address', 'your-prefix' ),
-						'email'   => __( 'Email', 'your-prefix' ),
+						'name'    =>esc_html__( 'Name', 'your-prefix' ),
+						'address' =>esc_html__( 'Address', 'your-prefix' ),
+						'email'   =>esc_html__( 'Email', 'your-prefix' ),
 					),
 					'clone'   => true,
 				),
@@ -198,20 +198,20 @@ add_filter(
 				// Text list
 				array(
 					'id'      => 'text_list',
-					'name'    => __( 'Text List', 'your-prefix' ),
+					'name'    =>esc_html__( 'Text List', 'your-prefix' ),
 					'type'    => 'text_list',
 					'options' => array(
-						'John Smith'      => __( 'Name', 'your-prefix' ),
-						'name@domain.com' => __( 'Email', 'your-prefix' ),
+						'John Smith'      =>esc_html__( 'Name', 'your-prefix' ),
+						'name@domain.com' =>esc_html__( 'Email', 'your-prefix' ),
 					),
 				),
 				array(
 					'id'      => 'text_list2',
-					'name'    => __( 'Text List Clone', 'your-prefix' ),
+					'name'    =>esc_html__( 'Text List Clone', 'your-prefix' ),
 					'type'    => 'text_list',
 					'options' => array(
-						'John Smith'      => __( 'Name', 'your-prefix' ),
-						'name@domain.com' => __( 'Email', 'your-prefix' ),
+						'John Smith'      =>esc_html__( 'Name', 'your-prefix' ),
+						'name@domain.com' =>esc_html__( 'Email', 'your-prefix' ),
 					),
 					'clone'   => true,
 				),
@@ -219,17 +219,17 @@ add_filter(
 				// File
 				array(
 					'id'   => 'file',
-					'name' => __( 'File', 'your-prefix' ),
+					'name' =>esc_html__( 'File', 'your-prefix' ),
 					'type' => 'file',
 				),
 				array(
 					'id'   => 'fileadv',
-					'name' => __( 'File Advanced', 'your-prefix' ),
+					'name' =>esc_html__( 'File Advanced', 'your-prefix' ),
 					'type' => 'file_advanced',
 				),
 				array(
 					'id'    => 'fileadv2',
-					'name'  => __( 'File Advanced Clone', 'your-prefix' ),
+					'name'  =>esc_html__( 'File Advanced Clone', 'your-prefix' ),
 					'type'  => 'file_advanced',
 					'clone' => true,
 				),
@@ -237,17 +237,17 @@ add_filter(
 				// Image
 				array(
 					'id'   => 'image',
-					'name' => __( 'Image', 'your-prefix' ),
+					'name' =>esc_html__( 'Image', 'your-prefix' ),
 					'type' => 'image',
 				),
 				array(
 					'id'   => 'image_advanced',
-					'name' => __( 'Image Advanced', 'your-prefix' ),
+					'name' =>esc_html__( 'Image Advanced', 'your-prefix' ),
 					'type' => 'image_advanced',
 				),
 				array(
 					'id'    => 'image_advanced2',
-					'name'  => __( 'Image Advanced Clone', 'your-prefix' ),
+					'name'  =>esc_html__( 'Image Advanced Clone', 'your-prefix' ),
 					'type'  => 'image_advanced',
 					'clone' => true,
 				),

--- a/tests/008-input-types.php
+++ b/tests/008-input-types.php
@@ -60,9 +60,9 @@ add_filter(
 					'id'      => 'fieldset_text',
 					'type'    => 'fieldset_text',
 					'options' => array(
-						'name'    => __( 'Name', 'your-prefix' ),
-						'address' => __( 'Address', 'your-prefix' ),
-						'email'   => __( 'Email', 'your-prefix' ),
+						'name'    =>esc_html__( 'Name', 'your-prefix' ),
+						'address' =>esc_html__( 'Address', 'your-prefix' ),
+						'email'   =>esc_html__( 'Email', 'your-prefix' ),
 					),
 				],
 				[

--- a/tests/011-choices.php
+++ b/tests/011-choices.php
@@ -3,11 +3,11 @@ add_filter( 'rwmb_meta_boxes', 'your_prefix_choice_demo' );
 function your_prefix_choice_demo( $meta_boxes ) {
 	$prefix       = '';
 	$meta_boxes[] = array(
-		'title'  => __( 'Hierarchical Options', 'your-prefix' ),
+		'title'  =>esc_html__( 'Hierarchical Options', 'your-prefix' ),
 		'fields' => array(
 			array(
 				'id'      => $prefix . 'checkbox_list',
-				'name'    => __( 'Flat Checkbox', 'your-prefix' ),
+				'name'    =>esc_html__( 'Flat Checkbox', 'your-prefix' ),
 				'type'    => 'checkbox_list',
 				// Old options syntax
 				'options' => array(
@@ -19,7 +19,7 @@ function your_prefix_choice_demo( $meta_boxes ) {
 
 			array(
 				'id'       => $prefix . 'checkbox_tree',
-				'name'     => __( 'Hierarchical Checkbox', 'your-prefix' ),
+				'name'     =>esc_html__( 'Hierarchical Checkbox', 'your-prefix' ),
 				'type'     => 'checkbox_list',
 				// New options syntax.  Supports hierarchical options with addition of parent
 				'options'  => array(
@@ -57,7 +57,7 @@ function your_prefix_choice_demo( $meta_boxes ) {
 
 			array(
 				'id'      => $prefix . 'select',
-				'name'    => __( 'Hierarchical select', 'your-prefix' ),
+				'name'    =>esc_html__( 'Hierarchical select', 'your-prefix' ),
 				'type'    => 'select',
 				'options' => array(
 					array(


### PR DESCRIPTION
Hi, 
I have replaced the following functions with better functions to pass the code review by Codecanyon:

- replace function: `die()` with `wp_die()`
- replaced function: `json_encode()` with `wp_json_encode()`
- replaced function: `__()` with `esc_html__()`
- replaced function: `_x()` with `esc_html_x()`