### PR TITLE
Enable AJAX delay for select_advanced field

### DIFF
--- a/js/select-advanced.js
+++ b/js/select-advanced.js
@@ -27,6 +27,10 @@
 	function transform() {
 		var $this = $( this ),
 			options = $this.data( 'options' );
+		
+		if ( options.ajax && !options.ajax.delay ) {
+			options.ajax.delay = 350;
+		}
 
 		$this.removeClass( 'select2-hidden-accessible' ).removeAttr( 'data-select2-id' );
 		$this.siblings( '.select2-container' ).remove();


### PR DESCRIPTION
Right now the select_advanced field for every input change event, not sure how to set the AJX delay from the `js_options` parameter, but i figure out the solution by set the AJAX delay value by editing the select-advanced.js