### PR TITLE
Fixing validation rules still applied for hidden fields

### DIFF
--- a/js/validate.js
+++ b/js/validate.js
@@ -14,7 +14,7 @@ jQuery( function ( $ ) {
 				$form.trigger( 'after_validate' );
 			}, 200 );
 		},
-		ignore: ':not([class|="rwmb"])',
+		ignore: ':not([class|="rwmb"]:visible)',
 		errorPlacement: function( error, element ) {
 			error.appendTo( element.closest( '.rwmb-input' ) );
 		},


### PR DESCRIPTION
There is a case I need to hide a field using Meta Box Conditional Logic and set it as required, and the validation should executed only when the field is visible.