### PR TITLE
strtolower() fails in some environments

### DIFF
--- a/inc/autoloader.php
+++ b/inc/autoloader.php
@@ -55,7 +55,7 @@ class RWMB_Autoloader {
 			if ( $dir['suffix'] && strlen( $file ) > strlen( $dir['suffix'] ) ) {
 				$file = substr( $file, 0, - strlen( $dir['suffix'] ) );
 			}
-			if ( function_exists( 'mb_strtolower' ) && function_exists( 'mb_strtolower' )  ) {
+			if ( function_exists( 'mb_strtolower' ) && function_exists( 'mb_detect_encoding' )  ) {
 				$file = mb_strtolower( str_replace( '_', '-', $file ), mb_detect_encoding( $file ) ) . '.php'
 			} else {
 				$file = strtolower( str_replace( '_', '-', $file ) ) . '.php';

--- a/inc/autoloader.php
+++ b/inc/autoloader.php
@@ -55,7 +55,7 @@ class RWMB_Autoloader {
 			if ( $dir['suffix'] && strlen( $file ) > strlen( $dir['suffix'] ) ) {
 				$file = substr( $file, 0, - strlen( $dir['suffix'] ) );
 			}
-			$file = strtolower( str_replace( '_', '-', $file ) ) . '.php';
+			$file = mb_strtolower( str_replace( '_', '-', $file ) ) . '.php';
 			$file = $dir['dir'] . $file;
 			$this->require_file( $file );
 		}

--- a/inc/autoloader.php
+++ b/inc/autoloader.php
@@ -55,7 +55,11 @@ class RWMB_Autoloader {
 			if ( $dir['suffix'] && strlen( $file ) > strlen( $dir['suffix'] ) ) {
 				$file = substr( $file, 0, - strlen( $dir['suffix'] ) );
 			}
-			$file = mb_strtolower( str_replace( '_', '-', $file ) ) . '.php';
+			if ( function_exists( 'mb_strtolower' ) && function_exists( 'mb_strtolower' )  ) {
+				$file = mb_strtolower( str_replace( '_', '-', $file ), mb_detect_encoding( $file ) ) . '.php'
+			} else {
+				$file = strtolower( str_replace( '_', '-', $file ) ) . '.php';
+			}
 			$file = $dir['dir'] . $file;
 			$this->require_file( $file );
 		}


### PR DESCRIPTION
@rilwis how's it going? Recently when I was debugging a server with Redux 4 I found this issue. Namely on some servers (especially with apache it seems) if the local is set in a different language some characters won't go lowercase which causes such pain with autoloaders.

Basically I fixed the issue in our code and found your class (which the user's environment was using) had the same issue.

So I'd suggest you do as I just did and do a mass search and replace for `strtolower()` to `mb_strtolower()`.

Hope all is well!  :)