### PR TITLE
Fix editor

### DIFF
--- a/css/wysiwyg.css
+++ b/css/wysiwyg.css
@@ -16,6 +16,6 @@
 }
 
 /* Fix fullscreen mode still shows admin menu */
-.mce-fullscreen {
+div.mce-fullscreen {
 	z-index: 999999;
 }

--- a/css/wysiwyg.css
+++ b/css/wysiwyg.css
@@ -14,3 +14,8 @@
 .block-editor .wp-editor-wrap {
 	box-sizing: content-box;
 }
+
+/* Fix fullscreen mode still shows admin menu */
+.mce-fullscreen {
+	z-index: 999999;
+}

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -50,19 +50,8 @@ class RWMB_Wysiwyg_Field extends RWMB_Field {
 			$options['editor_class'] .= ' rwmb-wysiwyg-required';
 		}
 
-		// Remove content_css to speedup.
-		$callback = function( $mceInit ) {
-			unset( $mceInit['content_css'] );
-			return $mceInit;
-		};
-
-		add_filter( 'teeny_mce_before_init', $callback );
-		add_filter( 'tiny_mce_before_init', $callback );
-
 		wp_editor( $meta, $attributes['id'], $options );
-
-		remove_filter( 'teeny_mce_before_init', $callback );
-		remove_filter( 'tiny_mce_before_init', $callback );
+		echo '<script class="rwmb-wysiwyg-id" type="text/html" data-id="', esc_attr( $attributes['id'] ), '"></script>';
 
 		return ob_get_clean();
 	}

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -10,13 +10,6 @@
  */
 class RWMB_Wysiwyg_Field extends RWMB_Field {
 	/**
-	 * Array of cloneable editors.
-	 *
-	 * @var array
-	 */
-	protected static $cloneable_editors = array();
-
-	/**
 	 * Enqueue scripts and styles.
 	 */
 	public static function admin_enqueue_scripts() {
@@ -57,7 +50,19 @@ class RWMB_Wysiwyg_Field extends RWMB_Field {
 			$options['editor_class'] .= ' rwmb-wysiwyg-required';
 		}
 
+		// Remove content_css to speedup.
+		$callback = function( $mceInit ) {
+			unset( $mceInit['content_css'] );
+			return $mceInit;
+		};
+
+		add_filter( 'teeny_mce_before_init', $callback );
+		add_filter( 'tiny_mce_before_init', $callback );
+
 		wp_editor( $meta, $attributes['id'], $options );
+
+		remove_filter( 'teeny_mce_before_init', $callback );
+		remove_filter( 'tiny_mce_before_init', $callback );
 
 		return ob_get_clean();
 	}

--- a/js/clone.js
+++ b/js/clone.js
@@ -230,22 +230,9 @@
 			start: function ( event, ui ) {
 				// Make the placeholder has the same height as dragged item
 				ui.placeholder.height( ui.item.outerHeight() );
-
-				// Fixed WYSIWYG field blank when inside a sortable, cloneable group.
-				// https://stackoverflow.com/a/25667486/371240
-				if ( window.tinymce ) {
-					ui.item.find( '.rwmb-wysiwyg' ).each( function () {
-						tinymce.execCommand( 'mceRemoveEditor', false, this.id );
-					} );
-				}
 			},
 			update: function( event, ui ) {
-				if ( window.tinymce ) {
-					ui.item.find( '.rwmb-wysiwyg' ).each( function () {
-						tinymce.execCommand( 'mceAddEditor', true, this.id );
-					} );
-				}
-
+				ui.item.trigger( 'mb_init_editors' );
 				ui.item.find( rwmb.inputSelectors ).first().trigger( 'mb_change' );
 			}
 		} );

--- a/js/clone.js
+++ b/js/clone.js
@@ -231,7 +231,7 @@
 				// Make the placeholder has the same height as dragged item
 				ui.placeholder.height( ui.item.outerHeight() );
 			},
-			update: function( event, ui ) {
+			stop: function( event, ui ) {
 				ui.item.trigger( 'mb_init_editors' );
 				ui.item.find( rwmb.inputSelectors ).first().trigger( 'mb_change' );
 			}

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -24,7 +24,7 @@
 		updateDom( $wrapper, id );
 
 		// Get id of the original editor to get its tinyMCE and quick tags settings
-		var originalId = getOriginalId( $this ),
+		var originalId = getOriginalId( this ),
 			settings = getEditorSettings( originalId );
 
 		// TinyMCE
@@ -41,9 +41,6 @@
 			settings.tinymce.init_instance_callback = function() {
 				switchEditors.go( id, mode );
 			}
-
-			// Remove content_css to speedup.
-			delete settings.tinymce.content_css;
 
 			tinymce.init( settings.tinymce );
 		}
@@ -83,20 +80,10 @@
 	/**
 	 * Get original ID of the textarea
 	 * The ID will be used to reference to tinyMCE and quick tags settings
-	 * @param $el Current cloned textarea
+	 * @param el Current cloned textarea
 	 */
-	function getOriginalId( $el ) {
-		var $clone = $el.closest( '.rwmb-clone' ),
-			currentId = $clone.find( '.rwmb-wysiwyg' ).attr( 'id' );
-
-		if ( /_\d+$/.test( currentId ) ) {
-			currentId = currentId.replace( /_\d+$/, '' );
-		}
-		if ( tinyMCEPreInit.mceInit.hasOwnProperty( currentId ) || tinyMCEPreInit.qtInit.hasOwnProperty( currentId ) ) {
-			return currentId;
-		}
-
-		return '';
+	function getOriginalId( el ) {
+		return el.closest( '.rwmb-clone' ).querySelector( '.rwmb-wysiwyg-id' ).dataset.id;
 	}
 
 	/**

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -40,6 +40,7 @@
 					$this.trigger( 'change' );
 				} );
 			}
+			delete settings.tinymce.content_css;
 
 			tinymce.init( settings.tinymce );
 		}

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -138,24 +138,6 @@
 			.find( '.quicktags-toolbar' ).attr( 'id', 'qt_' + id + '_toolbar' ).html( '' );
 	}
 
-	/**
-	 * Handles updating tiny mce instances when saving a gutenberg post.
-	 * https://metabox.io/support/topic/data-are-not-saved-into-the-database/
-	 * https://github.com/WordPress/gutenberg/issues/7176
-	 */
-	function ensureSave() {
-		if ( !wp.data || !wp.data.hasOwnProperty( 'subscribe' ) || !window.tinyMCE ) {
-			return;
-		}
-		wp.data.subscribe( function() {
-			var editor = wp.data.hasOwnProperty( 'select' ) ? wp.data.select( 'core/editor' ) : {};
-
-			if ( editor && editor.isSavingPost && editor.isSavingPost() ) {
-				window.tinyMCE.triggerSave();
-			}
-		} );
-	}
-
 	function init( e ) {
 		$( e.target ).find( '.rwmb-wysiwyg' ).each( transform );
 	}
@@ -167,7 +149,6 @@
 		}, 0 );
 	} );
 
-	ensureSave();
 	rwmb.$document
 		.on( 'mb_blocks_edit', init )
 		.on( 'mb_init_editors', init )

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -16,8 +16,6 @@
 			return;
 		}
 
-		addRequiredAttribute( $this );
-
 		// Update the ID attribute if the editor is in a new block.
 		if ( isInBlock ) {
 			id = id + '_' + rwmb.uniqid();
@@ -55,9 +53,9 @@
 		renderedEditors.push( id );
 	}
 
-	function addRequiredAttribute( $el ) {
-		if ( $el.hasClass( 'rwmb-wysiwyg-required' ) ) {
-			$el.prop( 'required', true );
+	function addRequiredAttribute() {
+		if ( this.classList.contains( 'rwmb-wysiwyg-required' ) ) {
+			this.setAttribute( 'required', true );
 		}
 	}
 
@@ -144,14 +142,17 @@
 		$( e.target ).find( '.rwmb-wysiwyg' ).each( transform );
 	}
 
-	// Force re-render editors in Gutenberg. Use setTimeOut to run after all other code. Bug occurs in WP 5.6.
-	if ( rwmb.isGutenberg ) {
-		$( function() {
+	$( function() {
+		var $editors = $( '.rwmb-wysiwyg' );
+		$editors.each( addRequiredAttribute );
+
+		// Force re-render editors in Gutenberg. Use setTimeOut to run after all other code. Bug occurs in WP 5.6.
+		if ( rwmb.isGutenberg ) {
 			setTimeout( function() {
-				$( '.rwmb-wysiwyg' ).each( transform );
+				$editors.each( transform );
 			}, 0 );
-		} );
-	}
+		}
+	} );
 
 	rwmb.$document
 		.on( 'mb_blocks_edit', init )

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -34,15 +34,14 @@
 
 		// TinyMCE
 		if ( window.tinymce ) {
-			var editor = new tinymce.Editor( id, settings.tinymce, tinymce.EditorManager );
-			editor.render();
+			settings.tinymce.selector = '#' + id;
+			settings.tinymce.setup = function( editor ) {
+				editor.on( 'keyup change', function() {
+					$this.trigger( 'change' );
+				} );
+			}
 
-			editor.on( 'keyup change', function() {
-				editor.save();
-				$this.trigger( 'change' );
-			} );
-
-			renderedEditors.push( id );
+			tinymce.init( settings.tinymce );
 		}
 
 		// Quick tags
@@ -51,6 +50,8 @@
 			quicktags( settings.quicktags );
 			QTags._buttonsInit();
 		}
+
+		renderedEditors.push( id );
 	}
 
 	function addRequiredAttribute( $el ) {

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -42,6 +42,7 @@
 				switchEditors.go( id, mode );
 			}
 
+			// Remove content_css to speedup.
 			delete settings.tinymce.content_css;
 
 			tinymce.init( settings.tinymce );

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -1,8 +1,6 @@
 ( function( $, wp, window, rwmb ) {
 	'use strict';
 
-	var renderedEditors = [];
-
 	/**
 	 * Transform textarea into wysiwyg editor.
 	 */
@@ -11,10 +9,6 @@
 			$wrapper = $this.closest( '.wp-editor-wrap' ),
 			id = $this.attr( 'id' ),
 			isInBlock = $this.closest( '.wp-block' ).length > 0;
-
-		if ( renderedEditors.includes( id ) ) {
-			return;
-		}
 
 		// Update the ID attribute if the editor is in a new block.
 		if ( isInBlock ) {
@@ -59,8 +53,6 @@
 			quicktags( settings.quicktags );
 			QTags._buttonsInit();
 		}
-
-		renderedEditors.push( id );
 	}
 
 	function getEditorSettings( id ) {

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -144,12 +144,14 @@
 		$( e.target ).find( '.rwmb-wysiwyg' ).each( transform );
 	}
 
-	// Force re-render editors. Use setTimeOut to run after all other code. Bug occurs in WP 5.6.
-	$( function() {
-		setTimeout( function() {
-			$( '.rwmb-wysiwyg' ).each( transform );
-		}, 0 );
-	} );
+	// Force re-render editors in Gutenberg. Use setTimeOut to run after all other code. Bug occurs in WP 5.6.
+	if ( rwmb.isGutenberg ) {
+		$( function() {
+			setTimeout( function() {
+				$( '.rwmb-wysiwyg' ).each( transform );
+			}, 0 );
+		} );
+	}
 
 	rwmb.$document
 		.on( 'mb_blocks_edit', init )

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -22,6 +22,9 @@
 			$this.attr( 'id', id );
 		}
 
+		// Get current editor mode before updating the DOM.
+		var mode = $wrapper.hasClass( 'tmce-active' ) ? 'tmce' : 'html';
+
 		// Update the DOM
 		$this.show();
 		updateDom( $wrapper, id );
@@ -39,6 +42,12 @@
 					$this.trigger( 'change' );
 				} );
 			}
+
+			// Set editor mode after initializing.
+			settings.tinymce.init_instance_callback = function() {
+				switchEditors.go( id, mode );
+			}
+
 			delete settings.tinymce.content_css;
 
 			tinymce.init( settings.tinymce );

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -161,9 +161,10 @@
 		if ( ! editor ) {
 			return;
 		}
-		editor.on( 'keyup change', function( editor ) {
+		var $this = $( this );
+		editor.on( 'keyup change', function() {
 			editor.save(); // Required for live validation.
-			$( this ).trigger( 'change' );
+			$this.trigger( 'change' );
 		} );
 	}
 

--- a/js/wysiwyg.js
+++ b/js/wysiwyg.js
@@ -83,7 +83,7 @@
 	 * @param el Current cloned textarea
 	 */
 	function getOriginalId( el ) {
-		return el.closest( '.rwmb-clone' ).querySelector( '.rwmb-wysiwyg-id' ).dataset.id;
+		return el.closest( '.rwmb-input' ).querySelector( '.rwmb-wysiwyg-id' ).dataset.id;
 	}
 
 	/**


### PR DESCRIPTION
- Fix editor blank in Gutenberg
- Fix content in the visual tab not saving


What is done:

- Re-render editors in Gutenberg editor, don't re-render in classic editor.
- While re-render, respect default editor mode (which can be set via a filter).
- Apply re-render after reorder editors, or groups that contain editors.
- Update the fix for validation, e.g. required rule now working for editors as well.