### PR TITLE
Clone Minimum & Updated Leaflet Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 package-lock.json
 yarn.lock
+.DS_Store

--- a/inc/field.php
+++ b/inc/field.php
@@ -105,10 +105,12 @@ abstract class RWMB_Field {
 			);
 		}
 
+		$data_min_clone = is_numeric( $field['min_clone'] ) && $field['min_clone'] > 1 ? ' data-min-clone=' . $field['min_clone'] : '';
 		$data_max_clone = is_numeric( $field['max_clone'] ) && $field['max_clone'] > 1 ? ' data-max-clone=' . $field['max_clone'] : '';
 
 		$input_open = sprintf(
-			'<div class="rwmb-input"%s>',
+			'<div class="rwmb-input" %s %s>',
+			$data_min_clone,
 			$data_max_clone
 		);
 
@@ -339,6 +341,7 @@ abstract class RWMB_Field {
 				'save_field'        => true,
 
 				'clone'             => false,
+				'min_clone'         => 0,
 				'max_clone'         => 0,
 				'sort_clone'        => false,
 				'add_button'        => __( '+ Add more', 'meta-box' ),

--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -15,8 +15,8 @@ class RWMB_OSM_Field extends RWMB_Field {
 	 */
 	public static function admin_enqueue_scripts() {
 		// Because map is a hosted service, it's ok to use hosted Leaflet scripts.
-		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.css', array(), '1.5.1' );
-		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.5.1/dist/leaflet.js', array(), '1.5.1', true );
+		wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.7.1/dist/leaflet.css', array(), '1.7.1' );
+		wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.7.1/dist/leaflet.js', array(), '1.7.1', true );
 
 		wp_enqueue_style( 'rwmb-osm', RWMB_CSS_URL . 'osm.css', array( 'leaflet' ), RWMB_VER );
 		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', array( 'jquery', 'jquery-ui-autocomplete', 'leaflet' ), RWMB_VER, true );

--- a/js/clone.js
+++ b/js/clone.js
@@ -156,8 +156,14 @@
 	 * @param $container .rwmb-input container
 	 */
 	function toggleRemoveButtons( $container ) {
-		var $clones = $container.children( '.rwmb-clone' );
-		$clones.children( '.remove-clone' ).toggle( $clones.length > 1 );
+
+		var $clones = $container.children( '.rwmb-clone' ),
+		    minClone = 1;
+	
+		if($container.data( 'min-clone' )){
+			minClone = parseInt( $container.data( 'min-clone' ) );
+		}
+		$clones.children( '.remove-clone' ).toggle( $clones.length > minClone );
 
 		// Recursive for nested groups.
 		$container.find( '.rwmb-input' ).each( function () {

--- a/js/clone.js
+++ b/js/clone.js
@@ -160,7 +160,7 @@
 		var $clones = $container.children( '.rwmb-clone' ),
 		    minClone = 1;
 	
-		if($container.data( 'min-clone' )){
+		if( $container.data( 'min-clone' ) ){
 			minClone = parseInt( $container.data( 'min-clone' ) );
 		}
 		$clones.children( '.remove-clone' ).toggle( $clones.length > minClone );

--- a/js/clone.js
+++ b/js/clone.js
@@ -160,7 +160,7 @@
 		var $clones = $container.children( '.rwmb-clone' ),
 		    minClone = 1;
 	
-		if( $container.data( 'min-clone' ) ){
+		if ( $container.data( 'min-clone' ) ) {
 			minClone = parseInt( $container.data( 'min-clone' ) );
 		}
 		$clones.children( '.remove-clone' ).toggle( $clones.length > minClone );


### PR DESCRIPTION
Added the ability to set clone_min attribute that toggles the remove-clone buttons off when the list is at the defined minimum value (not just one).

Updated the leaflet library to 1.7.1 from the outdated 1.5.1 version.

Updated the .gitignore file to also igmore .DS_Store files from MacOS devices.