### PR TITLE
Remove 'image' type requirement for thumbnails

### DIFF
--- a/inc/templates/media.php
+++ b/inc/templates/media.php
@@ -1,7 +1,7 @@
 <script id="tmpl-rwmb-media-item" type="text/html">
 	<input type="hidden" name="{{{ data.controller.fieldName }}}" value="{{{ data.id }}}" class="rwmb-media-input">
 	<div class="rwmb-file-icon">
-		<# if ( 'image' === data.type && data.sizes ) { #>
+		<# if ( data.sizes ) { #>
 			<# if ( data.sizes.thumbnail ) { #>
 				<img src="{{{ data.sizes.thumbnail.url }}}">
 			<# } else { #>


### PR DESCRIPTION
Many non-image file types may provide image thumbnails in WordPress. The most common example may be 'application/pdf' which often generates thumbnail images that WP uses as icons for these files. WP reports these images in `data.sizes` when doing the `wp_prepare_attachment_for_js()` that these "File Advanced" elements use (in /inc/fields/media.php) to generate the data that this template then renders. By requiring a type of `'image'` before allowing a check for `data.sizes`, Meta Box currently is forced to render a dull and uninformative icon for PDF files, even when a better image was supplied in `data.sizes`. 

Why not trust WordPress? If it supplies `data.sizes` we should use it regardless of the mime type! I propose we remove this test for `'image' === data.type` use `data.sizes` whenever they are present.

The irony is that the non-advanced File field already behaves this way and shows the nicer icons for files like PDF. It is on the File Advanced field that is so ugly.

File Advanced as it appears now:
<img width="229" alt="Screenshot of Arc (2023-02-02, 10-34-12 PM)" src="https://user-images.githubusercontent.com/604967/216513265-ea08101b-f50c-4b50-afd9-647ea05c9a71.png">

File Advanced as it would appear with this change:
<img width="248" alt="Screenshot of Arc (2023-02-02, 10-34-48 PM)" src="https://user-images.githubusercontent.com/604967/216513441-5abd3ae6-2543-4cbf-af5a-666a0ba0595d.png">


