### PR TITLE
Provide MB field ID in query variable args

### DIFF
--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -101,6 +101,7 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
+			'mb_field_id'.           => $field['id'],
 		] );
 
 		$meta = wp_parse_id_list( (array) $meta );


### PR DESCRIPTION
From time to time consumers of Meta Box need to modify the query that Meta Box initiates in line 127 of this file. This is easy enough to do using various WordPress filters, such as the `posts_clauses` filter. However, it can be difficult to identify which queries belong to Meta Box. Our method to date has been to add a special query variable when defining a given field. But this is tedious and a bit error prone.

This change would provide such a `mb_field_id` query variable automatically, ensuring that developers could check for that variable and it's value before they modify any given query with WP filters.

For example, we have a use case where we need to add a prefix and suffix to the title values normally searched by the Select Advanced field. We add these by modifying the `'join'` and `'where'` clauses of the query with the `posts_clauses` filter. But we would like to make sure we only modify the intended field. We do this by adding a query var manually right now. But if MB provided this automatically, we could build a much more flexible plugin because we would not have to ask end-users to add query vars to hook this all together. We could just find the field identifier that MB supplies.

Another option to make this work would be to modify line 127 itself so that it filtered the `$args` before running the query.

```
$query = new WP_Query( self::filter( 'choice_args', $args, $field ) );
```

This would work in our case too, since we could use that filter to add the field ID variable ourselves. But while this approach is more flexible, it might also be a bit more dangerous and it has higher overhead than simply building the variable in from the beginning.
