### PR TITLE
Fix syntax error in mb_field_id

### DIFF
--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -101,7 +101,7 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
-			'mb_field_id'.           => $field['id'],
+			'mb_field_id'            => $field['id'],
 		] );
 
 		$meta = wp_parse_id_list( (array) $meta );


### PR DESCRIPTION
So sorry about that! I actually edited this one in GitHub itself and didn't realize I'd introduced a typo. My apologies!