### PR TITLE
Added the rwmb_ajax_results filter

### DIFF
--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -31,6 +31,9 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 		$items = self::query( null, $field );
 		$items = array_values( $items );
 
+		// Apply the 'rwmb_ajax_results' filter
+		$items = apply_filters( 'rwmb_ajax_results', $items, $field, $request );
+		
 		$data = [ 'items' => $items ];
 
 		// More items for pagination.


### PR DESCRIPTION
Added new 'rwmb_ajax_results' filter to allow developers to modify the returned AJAX results, allowing for things like 'Add new Item' to be appended to the results.

Example of how this would be used:


```
add_filter( 'rwmb_ajax_results', 'modify_ajax_results', 10, 3 );

function modify_ajax_results( $results, $field, $request ) {
	if ( 'venue' == $field['id'] ) {
		$create_new_option = array(
			'value' => 'create_new_vanue',
			'label' => '+ Create New',
		);
		array_push( $results, $create_new_option );
	}
	return $results;
}
```