### PR TITLE
Fix media templates missing in blocks

### DIFF
--- a/inc/fields/file-upload.php
+++ b/inc/fields/file-upload.php
@@ -36,6 +36,6 @@ class RWMB_File_Upload_Field extends RWMB_Media_Field {
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once RWMB_INC_DIR . 'templates/upload.php';
+		require RWMB_INC_DIR . 'templates/upload.php';
 	}
 }

--- a/inc/fields/image-advanced.php
+++ b/inc/fields/image-advanced.php
@@ -77,6 +77,6 @@ class RWMB_Image_Advanced_Field extends RWMB_Media_Field {
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once RWMB_INC_DIR . 'templates/image-advanced.php';
+		require RWMB_INC_DIR . 'templates/image-advanced.php';
 	}
 }

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -32,9 +32,12 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	}
 
 	public static function add_actions() {
-		// Print HTML templates for Customizer.
-		// Must called here instead of inside html() because content of the field is injected via JavaScript.
-		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
+		if ( is_customize_preview() ) {
+			add_action( 'customize_register', [ get_called_class(), 'print_templates' ] );
+		} else {
+			add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
+			add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
+		}
 	}
 
 	/**
@@ -75,10 +78,6 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	 * @return string
 	 */
 	public static function html( $meta, $field ) {
-		// Print HTML templates. Runs only when the field is outputted.
-		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
-		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
-
 		$attributes = static::get_attributes( $field, $meta );
 
 		$html = sprintf(

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -29,15 +29,13 @@ class RWMB_Media_Field extends RWMB_File_Field {
 			'or'                 => apply_filters( 'rwmb_media_or_string', _x( 'or', 'media', 'meta-box' ) ),
 			'uploadInstructions' => apply_filters( 'rwmb_media_upload_instructions_string', _x( 'Drop files here to upload', 'media', 'meta-box' ) ),
 		] );
-	}
 
-	public static function add_actions() {
 		// Print HTML templates for Customizer.
-		// Must called here instead of inside html() because content of the field is injected via JavaScript.
 		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
 
-		// Must called here instead of inside html() because when creating a custom block, the field is outputed via Ajax.
+		// Print HTML templates. Runs only when the field is outputted.
 		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
+		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
 	}
 
 	/**
@@ -78,9 +76,6 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	 * @return string
 	 */
 	public static function html( $meta, $field ) {
-		// Print HTML templates. Runs only when the field is outputted.
-		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
-
 		$attributes = static::get_attributes( $field, $meta );
 
 		$html = sprintf(

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -32,13 +32,9 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	}
 
 	public static function add_actions() {
-		if ( ! is_admin() && ! is_plugin_active( 'mb-frontend-submission/mb-frontend-submission.php' ) ) {
-			return;
-		}
-
+		// Print HTML templates for Customizer.
+		// Must called here instead of inside html() because content of the field is injected via JavaScript.
 		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
-		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
-		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
 	}
 
 	/**
@@ -79,6 +75,10 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	 * @return string
 	 */
 	public static function html( $meta, $field ) {
+		// Print HTML templates. Runs only when the field is outputted.
+		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
+		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
+
 		$attributes = static::get_attributes( $field, $meta );
 
 		$html = sprintf(

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -29,13 +29,10 @@ class RWMB_Media_Field extends RWMB_File_Field {
 			'or'                 => apply_filters( 'rwmb_media_or_string', _x( 'or', 'media', 'meta-box' ) ),
 			'uploadInstructions' => apply_filters( 'rwmb_media_upload_instructions_string', _x( 'Drop files here to upload', 'media', 'meta-box' ) ),
 		] );
+	}
 
-		// Print HTML templates for Customizer.
-		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
-
-		// Print HTML templates. Runs only when the field is outputted.
-		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
-		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
+	public static function add_actions() {
+		add_action( 'print_media_templates', [ get_called_class(), 'print_templates' ] );
 	}
 
 	/**
@@ -212,6 +209,6 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	 * Template for media item.
 	 */
 	public static function print_templates() {
-		require_once RWMB_INC_DIR . 'templates/media.php';
+		require RWMB_INC_DIR . 'templates/media.php';
 	}
 }

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -32,7 +32,7 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	}
 
 	public static function add_actions() {
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! is_plugin_active( 'mb-frontend-submission/mb-frontend-submission.php' ) ) {
 			return;
 		}
 

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -32,12 +32,13 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	}
 
 	public static function add_actions() {
-		if ( is_customize_preview() ) {
-			add_action( 'customize_register', [ get_called_class(), 'print_templates' ] );
-		} else {
-			add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
-			add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
+		if ( ! is_admin() ) {
+			return;
 		}
+
+		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
+		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
+		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
 	}
 
 	/**

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -35,6 +35,8 @@ class RWMB_Media_Field extends RWMB_File_Field {
 		// Print HTML templates for Customizer.
 		// Must called here instead of inside html() because content of the field is injected via JavaScript.
 		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
+
+		// Must called here instead of inside html() because when creating a custom block, the field is outputed via Ajax.
 		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
 	}
 

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -35,6 +35,7 @@ class RWMB_Media_Field extends RWMB_File_Field {
 		// Print HTML templates for Customizer.
 		// Must called here instead of inside html() because content of the field is injected via JavaScript.
 		add_action( 'customize_controls_print_footer_scripts', [ get_called_class(), 'print_templates' ] );
+		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
 	}
 
 	/**
@@ -76,7 +77,6 @@ class RWMB_Media_Field extends RWMB_File_Field {
 	 */
 	public static function html( $meta, $field ) {
 		// Print HTML templates. Runs only when the field is outputted.
-		add_action( 'admin_footer', [ get_called_class(), 'print_templates' ] );
 		add_action( 'wp_footer', [ get_called_class(), 'print_templates' ] );
 
 		$attributes = static::get_attributes( $field, $meta );

--- a/inc/fields/video.php
+++ b/inc/fields/video.php
@@ -127,6 +127,6 @@ class RWMB_Video_Field extends RWMB_Media_Field {
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once RWMB_INC_DIR . 'templates/video.php';
+		require RWMB_INC_DIR . 'templates/video.php';
 	}
 }


### PR DESCRIPTION
This PR fix the root cause of missing media templates [caused by Elementor](https://github.com/elementor/elementor/issues/23390) and WP 6.3.

The problem is that Elementor calls `wp_print_media_template()`, which Meta Box uses to output media templates. However, in WP 6.3, WP gathers all styles and scripts to use in the block editor. Because Meta Box used `require_once`, the media templates are outputted once when Elementor calls `wp_print_media_template()`, and are gathered. Changing it to `require` makes the templates display as they should be.

This PR is the final fix for this series:
- https://github.com/wpmetabox/meta-box/commit/109f748f08f19013acd847165387796a7f82296f
- https://github.com/wpmetabox/meta-box/commit/c27138c986ddf69a5bf1320c53391c5771bb090a
- https://github.com/wpmetabox/meta-box/commit/c8c6b936ce3456a2ae30d0754011467b65f01e72

With this fix, we can close https://github.com/elementor/elementor/issues/23390.