### PR TITLE
fix: autocomplete and ajax clone.js

### DIFF
--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -26,8 +26,8 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 			$meta = [ $meta ];
 		}
 
-        // Filter out empty values in case the array started with empty or 0 values
-        $meta = array_filter( $meta );
+		// Filter out empty values in case the array started with empty or 0 values
+		$meta = array_filter( $meta );
 
 		$field   = apply_filters( 'rwmb_autocomplete_field', $field, $meta );
 		$options = $field['options'];

--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -26,6 +26,9 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 			$meta = [ $meta ];
 		}
 
+        // Filter out empty values in case the array started with empty or 0 values
+        $meta = array_filter( $meta );
+
 		$field   = apply_filters( 'rwmb_autocomplete_field', $field, $meta );
 		$options = $field['options'];
 

--- a/js/clone.js
+++ b/js/clone.js
@@ -71,6 +71,13 @@
 		 */
 		nextIndex: function ( $container ) {
 			var nextIndex = $container.data( 'next-index' );
+
+            // If we render cloneable fields via AJAX, the mb_ready event is not fired.
+            // so nextIndex is undefined. In this case, we get the next index from the number of existing clones.
+            if ( nextIndex === undefined ) {
+                nextIndex = $container.children( '.rwmb-clone' ).length;
+            }
+
 			$container.data( 'next-index', nextIndex + 1 );
 			return nextIndex;
 		}

--- a/js/clone.js
+++ b/js/clone.js
@@ -72,11 +72,11 @@
 		nextIndex: function ( $container ) {
 			var nextIndex = $container.data( 'next-index' );
 
-            // If we render cloneable fields via AJAX, the mb_ready event is not fired.
-            // so nextIndex is undefined. In this case, we get the next index from the number of existing clones.
-            if ( nextIndex === undefined ) {
-                nextIndex = $container.children( '.rwmb-clone' ).length;
-            }
+			// If we render cloneable fields via AJAX, the mb_ready event is not fired.
+			// so nextIndex is undefined. In this case, we get the next index from the number of existing clones.
+			if ( nextIndex === undefined ) {
+				nextIndex = $container.children( '.rwmb-clone' ).length;
+			}
 
 			$container.data( 'next-index', nextIndex + 1 );
 			return nextIndex;


### PR DESCRIPTION
This commit 

- fixes autocomplete when options have no key (starts at 0), it selects the first value by default.
- fixes clone.js when runs via ajax

```php
   [
      'id' => 'autocomplete',
      'name' => 'Autocomplete',
      'type' => 'autocomplete',
      'options' => [
          'Apple',
          'Orange',
          'Banana',
      ],
      'clone' => true,
  ]
```