### PR TITLE
fix: cannot save first value of autocomplete

### DIFF
--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -9,7 +9,7 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		wp_enqueue_style( 'rwmb-autocomplete', RWMB_CSS_URL . 'autocomplete.css', [], RWMB_VER );
 		wp_enqueue_script( 'rwmb-autocomplete', RWMB_JS_URL . 'autocomplete.js', [ 'jquery-ui-autocomplete' ], RWMB_VER, true );
 
-		RWMB_Helpers_Field::localize_script_once( 'rwmb-autocomplete', 'RWMB_Autocomplete', [
+		RWMB_Helpers_Field::localize_script_once( 'rwmb-autocomplete', 'RWMB_Autocomplete', [ 
 			'delete' => __( 'Delete', 'meta-box' ),
 		] );
 	}
@@ -27,7 +27,9 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		}
 
 		// Filter out empty values in case the array started with empty or 0 values
-		$meta = array_filter( $meta );
+		$meta = array_filter( $meta, function ($index) use ($meta) {
+			return $meta[$index] !== '';
+		}, ARRAY_FILTER_USE_KEY );
 
 		$field   = apply_filters( 'rwmb_autocomplete_field', $field, $meta );
 		$options = $field['options'];
@@ -35,8 +37,8 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		if ( is_array( $field['options'] ) ) {
 			$options = [];
 			foreach ( $field['options'] as $value => $label ) {
-				$options[] = [
-					'value' => $value,
+				$options[] = [ 
+					'value' => (string) $value,
 					'label' => $label,
 				];
 			}

--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -9,7 +9,7 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		wp_enqueue_style( 'rwmb-autocomplete', RWMB_CSS_URL . 'autocomplete.css', [], RWMB_VER );
 		wp_enqueue_script( 'rwmb-autocomplete', RWMB_JS_URL . 'autocomplete.js', [ 'jquery-ui-autocomplete' ], RWMB_VER, true );
 
-		RWMB_Helpers_Field::localize_script_once( 'rwmb-autocomplete', 'RWMB_Autocomplete', [ 
+		RWMB_Helpers_Field::localize_script_once( 'rwmb-autocomplete', 'RWMB_Autocomplete', [
 			'delete' => __( 'Delete', 'meta-box' ),
 		] );
 	}
@@ -27,8 +27,8 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		}
 
 		// Filter out empty values in case the array started with empty or 0 values
-		$meta = array_filter( $meta, function ($index) use ($meta) {
-			return $meta[$index] !== '';
+		$meta = array_filter( $meta, function ( $index ) use ( $meta ) {
+			return $meta[ $index ] !== '';
 		}, ARRAY_FILTER_USE_KEY );
 
 		$field   = apply_filters( 'rwmb_autocomplete_field', $field, $meta );
@@ -37,7 +37,7 @@ class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 		if ( is_array( $field['options'] ) ) {
 			$options = [];
 			foreach ( $field['options'] as $value => $label ) {
-				$options[] = [ 
+				$options[] = [
 					'value' => (string) $value,
 					'label' => $label,
 				];


### PR DESCRIPTION
This issue is related to JQuery UI treating the first element of array differently.

we have an array like:

```
['Foo', 'Bar', 'Baz']
```

If we select 'Bar' or 'Baz', `ui.item.value` returns 1 or 2, but if we select 'Foo', it returns its label instead of actual value, in this case, it returns 'Foo' instead of 0. So, the value returned is wrong.