### PR TITLE
Prepare css to be inlined

### DIFF
--- a/inc/fields/autocomplete.php
+++ b/inc/fields/autocomplete.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Autocomplete_Field extends RWMB_Multiple_Values_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-autocomplete', RWMB_CSS_URL . 'autocomplete.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-autocomplete', 'path', RWMB_CSS_DIR . 'autocomplete.css' );
 		wp_enqueue_script( 'rwmb-autocomplete', RWMB_JS_URL . 'autocomplete.js', [ 'jquery-ui-autocomplete' ], RWMB_VER, true );
 
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-autocomplete', 'RWMB_Autocomplete', [

--- a/inc/fields/background.php
+++ b/inc/fields/background.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Background_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-background', RWMB_CSS_URL . 'background.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-background', 'path', RWMB_CSS_DIR . 'background.css' );
 
 		$args  = func_get_args();
 		$field = reset( $args );

--- a/inc/fields/button-group.php
+++ b/inc/fields/button-group.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Button_Group_Field extends RWMB_Choice_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-button-group', RWMB_CSS_URL . 'button-group.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-button-group', 'path', RWMB_CSS_DIR . 'button-group.css' );
 		wp_enqueue_script( 'rwmb-button-group', RWMB_JS_URL . 'button-group.js', [ 'rwmb' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/color.php
+++ b/inc/fields/color.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Color_Field extends RWMB_Input_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-color', RWMB_CSS_URL . 'color.css', [ 'wp-color-picker' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-color', 'path', RWMB_CSS_DIR . 'color.css' );
 
 		$dependencies = [ 'wp-color-picker' ];
 		$args         = func_get_args();

--- a/inc/fields/datetime.php
+++ b/inc/fields/datetime.php
@@ -52,14 +52,23 @@ class RWMB_Datetime_Field extends RWMB_Input_Field {
 		// jQueryUI base theme: https://github.com/jquery/jquery-ui/tree/1.13.2/themes/base
 		$url = RWMB_CSS_URL . 'jqueryui';
 		wp_register_style( 'jquery-ui-core', "$url/core.css", [], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-core', 'path', RWMB_CSS_DIR . 'jqueryui/core.css' );
+
 		wp_register_style( 'jquery-ui-theme', "$url/theme.css", [], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-theme', 'path', RWMB_CSS_DIR . 'jqueryui/theme.css' );
+
 		wp_register_style( 'jquery-ui-datepicker', "$url/datepicker.css", [ 'jquery-ui-core', 'jquery-ui-theme' ], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-datepicker', 'path', RWMB_CSS_DIR . 'jqueryui/datepicker.css' );
+
 		wp_register_style( 'jquery-ui-slider', "$url/slider.css", [ 'jquery-ui-core', 'jquery-ui-theme' ], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-slider', 'path', RWMB_CSS_DIR . 'jqueryui/slider.css' );
 
 		// jQueryUI timepicker addon: https://github.com/trentrichardson/jQuery-Timepicker-Addon
 		wp_register_style( 'jquery-ui-timepicker', "$url/jquery-ui-timepicker-addon.min.css", [ 'rwmb-date', 'jquery-ui-slider' ], '1.6.3' );
+		wp_style_add_data( 'jquery-ui-timepicker', 'path', RWMB_CSS_DIR . 'jqueryui/jquery-ui-timepicker-addon.min.css' );
 
 		wp_register_style( 'rwmb-date', RWMB_CSS_URL . 'date.css', [ 'jquery-ui-datepicker' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-date', 'path', RWMB_CSS_DIR . 'date.css' );
 
 		// Scripts.
 		$url = RWMB_JS_URL . 'jqueryui';

--- a/inc/fields/divider.php
+++ b/inc/fields/divider.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Divider_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-divider', RWMB_CSS_URL . 'divider.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-divider', 'path', RWMB_CSS_DIR . 'divider.css' );
 	}
 
 	protected static function begin_html( array $field ) : string {

--- a/inc/fields/fieldset-text.php
+++ b/inc/fields/fieldset-text.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Fieldset_Text_Field extends RWMB_Input_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-fieldset-text', RWMB_CSS_URL . 'fieldset-text.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-fieldset-text', 'path', RWMB_CSS_DIR . 'fieldset-text.css' );
 	}
 
 	/**

--- a/inc/fields/file-input.php
+++ b/inc/fields/file-input.php
@@ -11,6 +11,7 @@ class RWMB_File_Input_Field extends RWMB_Input_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_media();
 		wp_enqueue_style( 'rwmb-file-input', RWMB_CSS_URL . 'file-input.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-file-input', 'path', RWMB_CSS_DIR . 'file-input.css' );
 		wp_enqueue_script( 'rwmb-file-input', RWMB_JS_URL . 'file-input.js', [ 'jquery' ], RWMB_VER, true );
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-file-input', 'rwmbFileInput', [
 			'frameTitle' => esc_html__( 'Select File', 'meta-box' ),

--- a/inc/fields/file-upload.php
+++ b/inc/fields/file-upload.php
@@ -8,6 +8,7 @@ class RWMB_File_Upload_Field extends RWMB_Media_Field {
 	public static function admin_enqueue_scripts() {
 		parent::admin_enqueue_scripts();
 		wp_enqueue_style( 'rwmb-upload', RWMB_CSS_URL . 'upload.css', [ 'rwmb-media' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-upload', 'path', RWMB_CSS_DIR . 'upload.css' );
 		wp_enqueue_script( 'rwmb-file-upload', RWMB_JS_URL . 'file-upload.js', [ 'rwmb-media' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/file.php
+++ b/inc/fields/file.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_File_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-file', RWMB_CSS_URL . 'file.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-file', 'path', RWMB_CSS_DIR . 'file.css' );
 		wp_enqueue_script( 'rwmb-file', RWMB_JS_URL . 'file.js', [ 'jquery-ui-sortable' ], RWMB_VER, true );
 
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-file', 'rwmbFile', [

--- a/inc/fields/heading.php
+++ b/inc/fields/heading.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Heading_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-heading', RWMB_CSS_URL . 'heading.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-heading', 'path', RWMB_CSS_DIR . 'heading.css' );
 	}
 
 	protected static function begin_html( array $field ) : string {

--- a/inc/fields/icon.php
+++ b/inc/fields/icon.php
@@ -11,6 +11,7 @@ class RWMB_Icon_Field extends RWMB_Select_Advanced_Field {
 		parent::admin_enqueue_scripts();
 
 		wp_enqueue_style( 'rwmb-icon', RWMB_CSS_URL . 'icon.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-icon', 'path', RWMB_CSS_DIR . 'icon.css' );
 		wp_enqueue_script( 'rwmb-icon', RWMB_JS_URL . 'icon.js', [ 'rwmb-select2', 'rwmb-select', 'underscore' ], RWMB_VER, true );
 
 		$args  = func_get_args();

--- a/inc/fields/image-select.php
+++ b/inc/fields/image-select.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Image_Select_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-image-select', RWMB_CSS_URL . 'image-select.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-image-select', 'path', RWMB_CSS_DIR . 'image-select.css' );
 		wp_enqueue_script( 'rwmb-image-select', RWMB_JS_URL . 'image-select.js', [ 'jquery' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/image.php
+++ b/inc/fields/image.php
@@ -9,6 +9,7 @@ class RWMB_Image_Field extends RWMB_File_Field {
 		parent::admin_enqueue_scripts();
 		wp_enqueue_media();
 		wp_enqueue_style( 'rwmb-image', RWMB_CSS_URL . 'image.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-image', 'path', RWMB_CSS_DIR . 'image.css' );
 	}
 
 	/**

--- a/inc/fields/input-list.php
+++ b/inc/fields/input-list.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Input_List_Field extends RWMB_Choice_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-input-list', RWMB_CSS_URL . 'input-list.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-input-list', 'path', RWMB_CSS_DIR . 'input-list.css' );
 		wp_enqueue_script( 'rwmb-input-list', RWMB_JS_URL . 'input-list.js', [], RWMB_VER, true );
 	}
 

--- a/inc/fields/input.php
+++ b/inc/fields/input.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 abstract class RWMB_Input_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-input', RWMB_CSS_URL . 'input.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-input', 'path', RWMB_CSS_DIR . 'input.css' );
 	}
 
 	/**

--- a/inc/fields/key-value.php
+++ b/inc/fields/key-value.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Key_Value_Field extends RWMB_Input_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-key-value', RWMB_CSS_URL . 'key-value.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-key-value', 'path', RWMB_CSS_DIR . 'key-value.css' );
 	}
 
 	/**

--- a/inc/fields/map.php
+++ b/inc/fields/map.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Map_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-map', RWMB_CSS_URL . 'map.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-map', 'path', RWMB_CSS_DIR . 'map.css' );
 
 		$args            = func_get_args();
 		$field           = $args[0];

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -13,6 +13,7 @@ class RWMB_Media_Field extends RWMB_File_Field {
 			wp_register_script( 'media-grid', includes_url( 'js/media-grid.min.js' ), [ 'media-editor' ], '4.9.7', true );
 		}
 		wp_enqueue_style( 'rwmb-media', RWMB_CSS_URL . 'media.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-media', 'path', RWMB_CSS_DIR . 'media.css' );
 		wp_enqueue_script( 'rwmb-media', RWMB_JS_URL . 'media.js', [ 'jquery-ui-sortable', 'underscore', 'backbone', 'media-grid' ], RWMB_VER, true );
 
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-media', 'i18nRwmbMedia', [

--- a/inc/fields/object-choice.php
+++ b/inc/fields/object-choice.php
@@ -142,6 +142,7 @@ abstract class RWMB_Object_Choice_Field extends RWMB_Choice_Field {
 		}
 
 		wp_enqueue_style( 'rwmb-modal', RWMB_CSS_URL . 'modal.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-modal', 'path', RWMB_CSS_DIR . 'modal.css' );
 		wp_enqueue_script( 'rwmb-modal', RWMB_JS_URL . 'modal.js', [ 'jquery' ], RWMB_VER, true );
 
 		$type = $field['type'] === 'taxonomy_advanced' ? 'taxonomy' : $field['type'];

--- a/inc/fields/oembed.php
+++ b/inc/fields/oembed.php
@@ -26,6 +26,7 @@ class RWMB_OEmbed_Field extends RWMB_Input_Field {
 
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-oembed', RWMB_CSS_URL . 'oembed.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-oembed', 'path', RWMB_CSS_DIR . 'oembed.css' );
 		wp_enqueue_script( 'rwmb-oembed', RWMB_JS_URL . 'oembed.js', [ 'jquery', 'underscore', 'rwmb' ], RWMB_VER, true );
 		wp_localize_script( 'rwmb-oembed', 'rwmbOembed', [
 			'nonce' => wp_create_nonce( 'oembed_get' ),

--- a/inc/fields/osm.php
+++ b/inc/fields/osm.php
@@ -9,6 +9,7 @@ class RWMB_OSM_Field extends RWMB_Field {
 		self::enqueue_map_assets();
 
 		wp_enqueue_style( 'rwmb-osm', RWMB_CSS_URL . 'osm.css', [ 'leaflet' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-osm', 'path', RWMB_CSS_DIR . 'osm.css' );
 		wp_enqueue_script( 'rwmb-osm', RWMB_JS_URL . 'osm.js', [ 'jquery', 'jquery-ui-autocomplete', 'leaflet' ], RWMB_VER, true );
 
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-osm', 'RWMB_Osm', [
@@ -129,6 +130,7 @@ class RWMB_OSM_Field extends RWMB_Field {
 		self::enqueue_map_assets();
 		wp_enqueue_script( 'rwmb-osm-frontend', RWMB_JS_URL . 'osm-frontend.js', [ 'jquery', 'leaflet' ], RWMB_VER, true );
 		wp_enqueue_style( 'rwmb-osm-frontend', RWMB_CSS_URL . 'osm-frontend.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-osm-frontend', 'path', RWMB_CSS_DIR . 'osm-frontend.css' );
 
 		/*
 		 * More Open Street Map options

--- a/inc/fields/range.php
+++ b/inc/fields/range.php
@@ -25,6 +25,7 @@ class RWMB_Range_Field extends RWMB_Number_Field {
 
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-range', RWMB_CSS_URL . 'range.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-range', 'path', RWMB_CSS_DIR . 'range.css' );
 		wp_enqueue_script( 'rwmb-range', RWMB_JS_URL . 'range.js', [], RWMB_VER, true );
 	}
 

--- a/inc/fields/select-advanced.php
+++ b/inc/fields/select-advanced.php
@@ -8,7 +8,10 @@ class RWMB_Select_Advanced_Field extends RWMB_Select_Field {
 	public static function admin_enqueue_scripts() {
 		parent::admin_enqueue_scripts();
 		wp_enqueue_style( 'rwmb-select2', RWMB_CSS_URL . 'select2/select2.css', [], '4.0.10' );
+		wp_style_add_data( 'rwmb-select2', 'path', RWMB_CSS_DIR . 'select2/select2.css' );
+
 		wp_enqueue_style( 'rwmb-select-advanced', RWMB_CSS_URL . 'select-advanced.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-select-advanced', 'path', RWMB_CSS_DIR . 'select-advanced.css' );
 
 		wp_register_script( 'rwmb-select2', RWMB_JS_URL . 'select2/select2.min.js', [ 'jquery' ], '4.0.10', true );
 

--- a/inc/fields/select-tree.php
+++ b/inc/fields/select-tree.php
@@ -21,6 +21,7 @@ class RWMB_Select_Tree_Field extends RWMB_Select_Advanced_Field {
 	public static function admin_enqueue_scripts() {
 		parent::admin_enqueue_scripts();
 		wp_enqueue_style( 'rwmb-select-tree', RWMB_CSS_URL . 'select-tree.css', [ 'rwmb-select' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-select-tree', 'path', RWMB_CSS_DIR . 'select-tree.css' );
 		wp_enqueue_script( 'rwmb-select-tree', RWMB_JS_URL . 'select-tree.js', [ 'rwmb-select' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/select.php
+++ b/inc/fields/select.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Select_Field extends RWMB_Choice_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-select', RWMB_CSS_URL . 'select.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-select', 'path', RWMB_CSS_DIR . 'select.css' );
 		wp_enqueue_script( 'rwmb-select', RWMB_JS_URL . 'select.js', [ 'jquery' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/slider.php
+++ b/inc/fields/slider.php
@@ -8,10 +8,16 @@ class RWMB_Slider_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		$url = RWMB_CSS_URL . 'jqueryui';
 		wp_register_style( 'jquery-ui-core', "$url/core.css", [], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-core', 'path', RWMB_CSS_DIR . 'jqueryui/core.css' );
+
 		wp_register_style( 'jquery-ui-theme', "$url/theme.css", [], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-theme', 'path', RWMB_CSS_DIR . 'jqueryui/theme.css' );
+
 		wp_register_style( 'jquery-ui-slider', "$url/slider.css", [ 'jquery-ui-core', 'jquery-ui-theme' ], '1.13.2' );
+		wp_style_add_data( 'jquery-ui-slider', 'path', RWMB_CSS_DIR . 'jqueryui/slider.css' );
 
 		wp_enqueue_style( 'rwmb-slider', RWMB_CSS_URL . 'slider.css', [ 'jquery-ui-slider' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-slider', 'path', RWMB_CSS_DIR . 'slider.css' );
 		wp_enqueue_script( 'rwmb-slider', RWMB_JS_URL . 'slider.js', [ 'jquery-ui-slider', 'jquery-ui-widget', 'jquery-ui-mouse', 'jquery-ui-core' ], RWMB_VER, true );
 	}
 

--- a/inc/fields/switch.php
+++ b/inc/fields/switch.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Switch_Field extends RWMB_Input_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-switch', RWMB_CSS_URL . 'switch.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-switch', 'path', RWMB_CSS_DIR . 'switch.css' );
 	}
 
 	/**

--- a/inc/fields/text-list.php
+++ b/inc/fields/text-list.php
@@ -7,6 +7,7 @@ defined( 'ABSPATH' ) || die;
 class RWMB_Text_List_Field extends RWMB_Multiple_Values_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_style( 'rwmb-text-list', RWMB_CSS_URL . 'text-list.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-text-list', 'path', RWMB_CSS_DIR . 'text-list.css' );
 	}
 
 	/**

--- a/inc/fields/video.php
+++ b/inc/fields/video.php
@@ -8,6 +8,7 @@ class RWMB_Video_Field extends RWMB_Media_Field {
 	public static function admin_enqueue_scripts() {
 		parent::admin_enqueue_scripts();
 		wp_enqueue_style( 'rwmb-video', RWMB_CSS_URL . 'video.css', [ 'rwmb-media' ], RWMB_VER );
+		wp_style_add_data( 'rwmb-video', 'path', RWMB_CSS_DIR . 'video.css' );
 		wp_enqueue_script( 'rwmb-video', RWMB_JS_URL . 'video.js', [ 'rwmb-media' ], RWMB_VER, true );
 		RWMB_Helpers_Field::localize_script_once( 'rwmb-video', 'i18nRwmbVideo', [
 			'extensions' => wp_get_video_extensions(),

--- a/inc/fields/wysiwyg.php
+++ b/inc/fields/wysiwyg.php
@@ -8,6 +8,7 @@ class RWMB_Wysiwyg_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts() {
 		wp_enqueue_editor();
 		wp_enqueue_style( 'rwmb-wysiwyg', RWMB_CSS_URL . 'wysiwyg.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-wysiwyg', 'path', RWMB_CSS_DIR . 'wysiwyg.css' );
 		wp_enqueue_script( 'rwmb-wysiwyg', RWMB_JS_URL . 'wysiwyg.js', [ 'jquery', 'rwmb' ], RWMB_VER, true );
 	}
 

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -19,6 +19,7 @@ class RWMB_Loader {
 		// Plugin paths, for including files.
 		define( 'RWMB_DIR', $path );
 		define( 'RWMB_INC_DIR', trailingslashit( RWMB_DIR . 'inc' ) );
+		define( 'RWMB_CSS_DIR', trailingslashit( RWMB_DIR . 'css' ) );
 	}
 
 	/**

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -115,8 +115,10 @@ class RW_Meta_Box {
 		}
 
 		wp_enqueue_style( 'rwmb', RWMB_CSS_URL . 'style.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb', 'path', RWMB_CSS_DIR . 'style.css' );
 		if ( is_rtl() ) {
 			wp_enqueue_style( 'rwmb-rtl', RWMB_CSS_URL . 'style-rtl.css', [], RWMB_VER );
+			wp_style_add_data( 'rwmb-rtl', 'path', RWMB_CSS_DIR . 'style-rtl.css' );
 		}
 
 		wp_enqueue_script( 'rwmb', RWMB_JS_URL . 'script.js', [ 'jquery' ], RWMB_VER, true );


### PR DESCRIPTION
By adding the path attribute to registered/enqueued style it allows WordPress to print some styles inline:
https://developer.wordpress.org/reference/functions/wp_maybe_inline_styles/

This is beneficial for front-end forms as the Meta Box field css files are mostly very small; inlining them reduces the number of http requests. 

I added the attribute to all styles for constencies sake; some of them will probably never be inline unless someone uses the 'styles_inline_size_limit' filter to increase to maximum size of inlined styles.