### PR TITLE
Security sanitize output

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 	 *
 	 * @return mixed false if field doesn't exist. Field value otherwise.
 	 */
-	function rwmb_get_value( $field_id, $args = [], $post_id = null, $secure_output = true) {
+	function rwmb_get_value( $field_id, $args = [], $post_id = null) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -160,9 +160,11 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 		 */
 		$value = apply_filters( 'rwmb_get_value', $value, $field, $args, $post_id );
 
+		$secure_output = $args['secure'] ?? true;
 		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
 		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
 		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
+		$secure_output = filter_var( $secure_output, FILTER_VALIDATE_BOOLEAN );
 
 		if ( $secure_output ) {
 			$value = wp_kses_post( $value );
@@ -183,7 +185,7 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 	 *
 	 * @return string
 	 */
-	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true, $secure_output = true) {
+	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -191,7 +193,7 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 			return '';
 		}
 
-		$output = RWMB_Field::call( 'the_value', $field, $args, $post_id, $secure_output );
+		$output = RWMB_Field::call( 'the_value', $field, $args, $post_id );
 
 		/*
 		 * Allow developers to change the returned value of field.
@@ -203,10 +205,12 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 		 * @param int|null $post_id Post ID. null for current post. Optional.
 		 */
 		$output = apply_filters( 'rwmb_the_value', $output, $field, $args, $post_id );
-
+		$secure_output = $args['secure'] ?? true;
+		
 		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
 		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
 		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
+		$secure_output = filter_var( $secure_output, FILTER_VALIDATE_BOOLEAN );
 
 		if ( $secure_output ) {
 			$output = wp_kses_post( $output );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 	 *
 	 * @return mixed false if field doesn't exist. Field value otherwise.
 	 */
-	function rwmb_get_value( $field_id, $args = [], $post_id = null ) {
+	function rwmb_get_value( $field_id, $args = [], $post_id = null, $secure_output = true) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -160,6 +160,14 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 		 */
 		$value = apply_filters( 'rwmb_get_value', $value, $field, $args, $post_id );
 
+		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
+		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
+		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
+
+		if ( $secure_output ) {
+			$value = wp_kses_post( $value );
+		}
+
 		return $value;
 	}
 }
@@ -175,7 +183,7 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 	 *
 	 * @return string
 	 */
-	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true ) {
+	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true, $secure_output = true) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -183,7 +191,7 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 			return '';
 		}
 
-		$output = RWMB_Field::call( 'the_value', $field, $args, $post_id );
+		$output = RWMB_Field::call( 'the_value', $field, $args, $post_id, $secure_output );
 
 		/*
 		 * Allow developers to change the returned value of field.
@@ -196,8 +204,16 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 		 */
 		$output = apply_filters( 'rwmb_the_value', $output, $field, $args, $post_id );
 
+		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
+		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
+		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
+
+		if ( $secure_output ) {
+			$output = wp_kses_post( $output );
+		}
+
 		if ( $echo ) {
-			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput
+			echo $output;
 		}
 
 		return $output;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 	 *
 	 * @return mixed false if field doesn't exist. Field value otherwise.
 	 */
-	function rwmb_get_value( $field_id, $args = [], $post_id = null) {
+	function rwmb_get_value( $field_id, $args = [], $post_id = null ) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -160,16 +160,6 @@ if ( ! function_exists( 'rwmb_get_value' ) ) {
 		 */
 		$value = apply_filters( 'rwmb_get_value', $value, $field, $args, $post_id );
 
-		$secure_output = $args['secure'] ?? true;
-		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
-		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
-		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
-		$secure_output = filter_var( $secure_output, FILTER_VALIDATE_BOOLEAN );
-
-		if ( $secure_output ) {
-			$value = wp_kses_post( $value );
-		}
-
 		return $value;
 	}
 }
@@ -185,7 +175,7 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 	 *
 	 * @return string
 	 */
-	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true) {
+	function rwmb_the_value( $field_id, $args = [], $post_id = null, $echo = true ) {
 		$args  = wp_parse_args( $args );
 		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
 
@@ -205,19 +195,9 @@ if ( ! function_exists( 'rwmb_the_value' ) ) {
 		 * @param int|null $post_id Post ID. null for current post. Optional.
 		 */
 		$output = apply_filters( 'rwmb_the_value', $output, $field, $args, $post_id );
-		$secure_output = $args['secure'] ?? true;
-		
-		$secure_output = apply_filters( 'rwmb_secure_output', $secure_output, $field, $args, $post_id );
-		$secure_output = apply_filters( "rwmb_secure_output_{$field['type']}", $secure_output, $field, $args, $post_id );
-		$secure_output = apply_filters( "rwmb_secure_output_{$field['id']}", $secure_output, $field, $args, $post_id );
-		$secure_output = filter_var( $secure_output, FILTER_VALIDATE_BOOLEAN );
-
-		if ( $secure_output ) {
-			$output = wp_kses_post( $output );
-		}
 
 		if ( $echo ) {
-			echo $output;
+			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 
 		return $output;

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -22,10 +22,18 @@ class RWMB_Shortcode {
 
 		$field_id  = $atts['id'];
 		$object_id = $atts['object_id'];
+		
 		unset( $atts['id'], $atts['object_id'] );
 
 		$value = $this->get_value( $field_id, $object_id, $atts );
 		$value = 'true' === $atts['render_shortcodes'] ? do_shortcode( $value ) : $value;
+
+		$secure = apply_filters( 'rwmb_meta_shortcode_secure', true, $field_id, $atts, $object_id );
+		$secure = apply_filters( "rwmb_meta_shortcode_secure_{$field_id}", $secure, $atts, $object_id );
+
+		if ( $secure ) {
+			$value = wp_kses_post( $value );
+		}
 
 		return $value;
 	}


### PR DESCRIPTION
Changes:

Shortcodes are now output safe html by default:

Example:
```
[rwmb_meta id="icon"]
```

To output unsafe html

```
add_filter('rwmb_meta_shortcode_secure', '__return_false');

OR

add_filter('rwmb_meta_shortcode_secure_icon', '__return_false');
```


