### PR TITLE
style: hide() instead of .remove()

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -10,8 +10,8 @@
 			<div class="rwmb-modal-content"></div>
 		</dialog>`,
 		markupIframe: '<iframe id="rwmb-modal-iframe" width="100%" height="700" src="{URL}" border="0"></iframe>',
-		removeElement: '',
-		removeElementDefault: '#adminmenumain, #wpadminbar, #wpfooter, .row-actions, .form-wrap.edit-term-notes, #screen-meta-links, .wp-heading-inline, .wp-header-end, .page-title-action',
+		hideElement: '',
+		hideElementDefault: '#adminmenumain, #wpadminbar, #wpfooter, .row-actions, .form-wrap.edit-term-notes, #screen-meta-links, .wp-heading-inline, .wp-header-end, .page-title-action',
 		callback: null,
 		closeModalCallback: null,
 		isBlockEditor: false,
@@ -52,7 +52,7 @@
 				const $contents = $( this ).contents();
 				options.isBlockEditor = $contents.find( 'body' ).hasClass( 'block-editor-page' );
 
-				$contents.find( options.removeElement ).remove();
+				$contents.find( options.hideElement ).hide();
 
 				$modal.find( '.rwmb-modal-title' ).css( 'background-color', '' );
 				if ( options.isBlockEditor ) {
@@ -60,8 +60,8 @@
 				}
 
 				$contents
-					.find( options.removeElementDefault ).remove().end()
-					.find( '.rwmb-modal-add-button' ).parent().remove();
+					.find( options.hideElementDefault ).hide().end()
+					.find( '.rwmb-modal-add-button' ).parents('.rwmb-field').hide();
 				$contents.find( 'html' ).css( 'padding-top', 0 ).end()
 					.find( '#wpcontent' ).css( 'margin-left', 0 ).end()
 					.find( 'a' ).on( 'click', e => e.preventDefault() );

--- a/js/post.js
+++ b/js/post.js
@@ -3,7 +3,7 @@
 
 	function addNew() {
 		$( this ).rwmbModal( {
-			removeElement: '#editor .interface-interface-skeleton__footer, .edit-post-fullscreen-mode-close',
+			hideElement: '#editor .interface-interface-skeleton__footer, .edit-post-fullscreen-mode-close',
             callback: function ( $modal, $modalContent ) {
                 $modalContent.find( 'body' ).addClass( 'is-fullscreen-mode' );
                 

--- a/js/taxonomy.js
+++ b/js/taxonomy.js
@@ -5,7 +5,7 @@
         const $this = $( this );
 
         $this.rwmbModal( {
-            removeElement: '.form-wrap > h2',
+            hideElement: '.form-wrap > h2',
             callback: function ( $modal, $modalContent ) {
                 $modalContent.find( '#col-right' ).css( 'display', 'none' );
                 $modalContent.find( '.search-box' ).css( 'display', 'none' );

--- a/js/user.js
+++ b/js/user.js
@@ -5,7 +5,7 @@
         const $this = $( this );
 
         $this.rwmbModal( {
-            removeElement: '#add-new-user',
+            hideElement: '#add-new-user',
             callback: function ( $modal, $modalContent ) {
                 $modalContent.find( '#add-new-user' ).next().next().remove();
 


### PR DESCRIPTION
Admin notices are displaying wrong when removing elements, so we need to hide instead of remove

https://wordpress.stackexchange.com/questions/220650/how-to-change-the-location-of-admin-notice-in-html-without-using-javascript