### PR TITLE
revert: use div instead of dialog

### DIFF
--- a/css/modal.css
+++ b/css/modal.css
@@ -3,16 +3,60 @@
 	margin-top: 6px;
 }
 
-/* Mimic style of media modal */
-.rwmb-modal {
-    width: 90%;
-    padding: 0;
-    border: none;
+body.rwmb-modal-show,
+body.rwmb-modal-show .interface-interface-skeleton__sidebar {
+	overflow: hidden;
 }
 
-.rwmb-modal::backdrop {
+/* Mimic style of media modal */
+.rwmb-modal {
+	position: fixed;
+	top: 30px;
+	left: 30px;
+	right: 30px;
+	bottom: 30px;
+	z-index: 160000;
+    margin: auto;
+	overflow: hidden;
+	border: 1px solid #c3c4c7;
+	background: #f0f0f1;
+	border-radius: 10px;
+	flex-direction: column;
+	box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+	display: none;
+}
+
+.rwmb-modal-sm {
+    max-width: 600px;
+}
+
+.rwmb-modal[size="small"] {
+    max-width: 600px;
+}
+
+.rwmb-modal-content {
+    overflow: hidden;
+    flex: 1;
+}
+
+iframe#rwmb-modal-iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+    overflow: hidden;
+}
+
+.rwmb-modal-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	min-height: 360px;
 	background: #000;
 	opacity: 0.7;
+	z-index: 159900;
+	display: none;
 }
 
 .rwmb-modal-title {

--- a/css/modal.css
+++ b/css/modal.css
@@ -18,16 +18,8 @@ body.rwmb-modal-show .interface-interface-skeleton__sidebar {
 	z-index: 160000;
     margin: auto;
 	overflow: hidden;
-	border: 1px solid #c3c4c7;
-	background: #f0f0f1;
-	border-radius: 10px;
 	flex-direction: column;
-	box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 	display: none;
-}
-
-.rwmb-modal-sm {
-    max-width: 600px;
 }
 
 .rwmb-modal[size="small"] {

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,14 +1,16 @@
 ( $ => {
 	'use strict';
+    
+    const $body = $( 'body' );
 
 	const defaultOptions = {
-		wrapper: `<dialog class="rwmb-modal" id="rwmb-modal">
-			<div class="rwmb-modal-title">
+		wrapper: `<div class="rwmb-modal">
+			<header class="rwmb-modal-title">
 				<h2></h2>
 				<button type="button" class="rwmb-modal-close">&times;</button>
-			</div>
+			</header>
 			<div class="rwmb-modal-content"></div>
-		</dialog>`,
+		</div>`,
 		markupIframe: '<iframe id="rwmb-modal-iframe" width="100%" height="700" src="{URL}" border="0"></iframe>',
 		hideElement: '',
 		hideElementDefault: '#adminmenumain, #wpadminbar, #wpfooter, .row-actions, .form-wrap.edit-term-notes, #screen-meta-links, .wp-heading-inline, .wp-header-end, .page-title-action',
@@ -16,7 +18,9 @@
 		closeModalCallback: null,
 		isBlockEditor: false,
 		$objectId: null,
-		$objectDisplay: null
+		$objectDisplay: null,
+        isEdit: false,
+        size: 'large',
 	};
 
 	$.fn.rwmbModal = function ( options = {} ) {
@@ -40,11 +44,8 @@
 
 		$this.click( function ( e ) {
 			e.preventDefault();
-
-			const dialog = document.getElementById( 'rwmb-modal' ); // New dialog element
-			// Show modal
-			dialog.showModal();
-
+            
+            $modal.attr( 'size', options.size );
 			$modal.find( '.rwmb-modal-title h2' ).html( $this.html() );
 			$modal.find( '.rwmb-modal-content' ).html( options.markupIframe.replace( '{URL}', $this.data( 'url' ) ) );
 
@@ -70,15 +71,21 @@
 					options.callback( $modal, $contents );
 				}
 
+                $body.addClass( 'rwmb-modal-show' );
+				$( '.rwmb-modal-overlay' ).fadeIn( 'medium' ).css( 'display', 'flex' );
+				$modal.fadeIn( 'medium' ).css( 'display', 'flex' );
+
 				return false;
 			} );
 
-			const closeModalHandler = function ( event ) {
+			$( '.rwmb-modal-close' ).on( 'click', function ( event ) {
 				if ( options.closeModalCallback !== null && typeof options.closeModalCallback === 'function' ) {
 					options.closeModalCallback( $( '#rwmb-modal-iframe' ).contents(), $input );
 				}
 
-				dialog.close();
+                $modal.fadeOut( 'medium' );
+				$( '.rwmb-modal-overlay' ).fadeOut( 'medium' );
+				$body.removeClass( 'rwmb-modal-show' );
 
 				// If not add new
 				if ( !options.$objectId || !options.$objectDisplay ) {
@@ -115,29 +122,13 @@
 				options.$objectId = null;
 				options.$objectDisplay = null;
 				$( this ).off( event );
-			};
-
-			// Close modal on click close button
-			$( '.rwmb-modal-close' ).on( 'click', closeModalHandler );
-
-			// Close modal on press ESC key
-			document.addEventListener( 'keydown', ( event ) => {
-				if ( event.key === 'Escape' ) {
-					closeModalHandler( event );
-				}
-			} );
-
-			// Close modal on click outside
-			dialog.addEventListener( 'click', function ( event ) {
-				if ( event.target === dialog ) {
-					closeModalHandler( event );
-				}
-			} );
+			});
 		} );
 	};
 
 	if ( $( '.rwmb-modal' ).length === 0 ) {
-		document.body.insertAdjacentHTML( 'beforeend', defaultOptions.wrapper );
+		$body.append( defaultOptions.wrapper )
+			.append( defaultOptions.markupOverlay );
 	}
 
 } )( jQuery );

--- a/js/modal.js
+++ b/js/modal.js
@@ -12,6 +12,7 @@
 			<div class="rwmb-modal-content"></div>
 		</div>`,
 		markupIframe: '<iframe id="rwmb-modal-iframe" width="100%" height="700" src="{URL}" border="0"></iframe>',
+        markupOverlay: '<div class="rwmb-modal-overlay"></div>',
 		hideElement: '',
 		hideElementDefault: '#adminmenumain, #wpadminbar, #wpfooter, .row-actions, .form-wrap.edit-term-notes, #screen-meta-links, .wp-heading-inline, .wp-header-end, .page-title-action',
 		callback: null,

--- a/js/taxonomy.js
+++ b/js/taxonomy.js
@@ -5,15 +5,12 @@
         const $this = $( this );
 
         $this.rwmbModal( {
+            size: 'small',
             hideElement: '.form-wrap > h2',
             callback: function ( $modal, $modalContent ) {
                 $modalContent.find( '#col-right' ).css( 'display', 'none' );
                 $modalContent.find( '.search-box' ).css( 'display', 'none' );
                 $modalContent.find( '#wpbody' ).css( 'padding-top', 0 );
-                $modal.css( {
-                    'max-width': '480px',
-                    'margin': 'auto',
-                } );
             },
             closeModalCallback: function ( $modal, $input ) {
                 if ( $modal.find( '#the-list tr:first td:eq(0) .row-actions' ).length > 0 ) {

--- a/js/user.js
+++ b/js/user.js
@@ -5,14 +5,10 @@
         const $this = $( this );
 
         $this.rwmbModal( {
+            size: 'small',
             hideElement: '#add-new-user',
             callback: function ( $modal, $modalContent ) {
                 $modalContent.find( '#add-new-user' ).next().next().remove();
-
-                $modal.css( {
-                    'max-width': '480px',
-                    'margin': 'auto',
-                } );
             },
             closeModalCallback: function ( $modal, $input ) {
                 if ( $modal.find( '#wpbody-content .wrap form input[name="_wp_http_referer"]' ).length > 0 ) {


### PR DESCRIPTION
Ngoài revert ra e còn fix 1 số lỗi nhỏ nữa, ví dụ như trong `user.js` và `taxonomy.js` mình set css width cho modal, tuy nhiên dùng `.css()` như thế thì modal sẽ bị set luôn css đó và khi mở lại modal `post` sẽ bị size nhỏ như `user` và `taxonomy`, do vậy e thêm 1 config là size, mặc định sẽ là `large`.

E set size vào attribute thay vì class vì như vậy code sẽ gọn hơn, thay vì remove class rồi add class thì chỉ cần set attribute thôi.