### PR TITLE
fix(modal): url's attribute not updated

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -45,10 +45,9 @@
 
 		$this.click( function ( e ) {
 			e.preventDefault();
-            
             $modal.attr( 'size', options.size );
 			$modal.find( '.rwmb-modal-title h2' ).html( $this.html() );
-			$modal.find( '.rwmb-modal-content' ).html( options.markupIframe.replace( '{URL}', $this.data( 'url' ) ) );
+			$modal.find( '.rwmb-modal-content' ).html( options.markupIframe.replace( '{URL}', $this.attr( 'data-url' ) ) );
 
 			$( '#rwmb-modal-iframe' ).on( 'load', function () {
 				const $contents = $( this ).contents();


### PR DESCRIPTION
E phát hiện ra 1 lỗi nhỏ là khi set attribute `url` thì URL trong modal không được update. Nguyên nhân là do `$.data('url')` bị cache. Mình dùng `$.attr('data-url')` thì sẽ không bị cache nữa.