### PR TITLE
Fix broken access control

### DIFF
--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -16,6 +16,9 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 		$request = rwmb_request();
 
 		$field = $request->filter_post( 'field', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		
+		// Do not allow users to manipulate the perm.
+		unset( $field['query_args']['perm'] );
 
 		// Required for 'choice_label' filter. See self::filter().
 		$field['clone']        = false;
@@ -106,6 +109,7 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
 			'mb_field_id'            => $field['id'],
+			'perm'					 => 'readable',
 		] );
 
 		$meta = wp_parse_id_list( (array) $meta );

--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -16,9 +16,6 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 		$request = rwmb_request();
 
 		$field = $request->filter_post( 'field', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
-		
-		// Do not allow users to manipulate the perm.
-		unset( $field['query_args']['perm'] );
 
 		// Required for 'choice_label' filter. See self::filter().
 		$field['clone']        = false;
@@ -109,8 +106,9 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
 			'mb_field_id'            => $field['id'],
-			'perm'					 => 'readable',
 		] );
+
+		$args['perm'] = 'readable';
 
 		$meta = wp_parse_id_list( (array) $meta );
 

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -18,9 +18,6 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 
 		$field = $request->filter_post( 'field', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
 		
-		// Do not allow users to manipulate the fields.
-		unset( $field['query_args']['fields'] );
-
 		// Required for 'choice_label' filter. See self::filter().
 		$field['clone']        = false;
 		$field['_original_id'] = $field['id'];
@@ -99,8 +96,13 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 
 	public static function query( $meta, array $field ): array {
 		$display_field = $field['display_field'];
-		
-		$query_args_fields = apply_filters( 'rwmb_user_query_args_fields', [
+
+		$args          = wp_parse_args( $field['query_args'], [
+			'orderby' => $display_field,
+			'order'   => 'asc',
+		] );
+
+		$args['fields']  = [
 			'ID',
 			'user_login',
 			'user_nicename',
@@ -108,13 +110,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 			'user_registered',
 			'user_status',
 			'display_name',
-		], $field );
-
-		$args          = wp_parse_args( $field['query_args'], [
-			'orderby' => $display_field,
-			'order'   => 'asc',
-			'fields'  => $query_args_fields,
-		] );
+		];
 
 		$meta = wp_parse_id_list( (array) $meta );
 

--- a/inc/fields/user.php
+++ b/inc/fields/user.php
@@ -17,6 +17,9 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		$request = rwmb_request();
 
 		$field = $request->filter_post( 'field', FILTER_DEFAULT, FILTER_FORCE_ARRAY );
+		
+		// Do not allow users to manipulate the fields.
+		unset( $field['query_args']['fields'] );
 
 		// Required for 'choice_label' filter. See self::filter().
 		$field['clone']        = false;
@@ -96,20 +99,21 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 
 	public static function query( $meta, array $field ): array {
 		$display_field = $field['display_field'];
+		
+		$query_args_fields = apply_filters( 'rwmb_user_query_args_fields', [
+			'ID',
+			'user_login',
+			'user_nicename',
+			'user_url',
+			'user_registered',
+			'user_status',
+			'display_name',
+		], $field );
+
 		$args          = wp_parse_args( $field['query_args'], [
 			'orderby' => $display_field,
 			'order'   => 'asc',
-			'fields'  => [
-				'ID',
-				'user_login',
-				'user_pass',
-				'user_nicename',
-				'user_email',
-				'user_url',
-				'user_registered',
-				'user_status',
-				'display_name',
-			],
+			'fields'  => $query_args_fields,
 		] );
 
 		$meta = wp_parse_id_list( (array) $meta );
@@ -132,7 +136,7 @@ class RWMB_User_Field extends RWMB_Object_Choice_Field {
 		$users   = get_users( $args );
 		$options = [];
 		foreach ( $users as $user ) {
-			$label = $user->$display_field ? $user->$display_field : __( '(No title)', 'meta-box' );
+			$label = $user->$display_field ?? __( '(No title)', 'meta-box' );
 			$label = self::filter( 'choice_label', $label, $field, $user );
 
 			$options[ $user->ID ] = [


### PR DESCRIPTION
E thấy term sẽ visible với tất cả user nên e không fix, không biết có trường hợp nào cần limit không?

Hướng xử lý của e:

## Post
- Thêm `perm` vào query, mặc định là `readable`.
- Không chấp nhận query `perm` qua ajax.

## User
- Ẩn `user_email` và `user_pass`.
- Không chấp nhận query `fields` qua ajax.
- Nếu người dùng vẫn muốn lấy `user_email` thì dùng filter như sau:

```
// This filter accepts two paramters
add_filter ('rwmb_user_query_args_fields', function ($args, $field) {
	return [
		'ID',
		'user_login',
		'user_email',
		'user_nicename',
		'user_url',
		'user_registered',
		'user_status',
		'display_name',
	];
}, 10, 2);
```

P/S: Thực ra e thấy config `fields` qua settings của field hay hơn là dùng filter, nhưng trong phần ajax làm sao lấy được $field qua field id nhỉ? Dùng `$field = rwmb_get_field_settings( $field_id );` thì với nhiều loại object_type, post type khác sợ ko chuẩn.