### PR TITLE
fix: wp query perm

### DIFF
--- a/inc/fields/post.php
+++ b/inc/fields/post.php
@@ -108,8 +108,6 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 			'mb_field_id'            => $field['id'],
 		] );
 
-		$args['perm'] = 'readable';
-
 		$meta = wp_parse_id_list( (array) $meta );
 
 		// Query only selected items.
@@ -135,6 +133,10 @@ class RWMB_Post_Field extends RWMB_Object_Choice_Field {
 
 		$options = [];
 		foreach ( $query->posts as $post ) {
+			if ( ! current_user_can( 'read_post', $post ) ) {
+				continue;
+			}
+			
 			$label                = $post->post_title ? $post->post_title : __( '(No title)', 'meta-box' );
 			$label                = self::filter( 'choice_label', $label, $field, $post );
 			$options[ $post->ID ] = [


### PR DESCRIPTION
Latest fix with `'perm' => 'readable'` doesn't work because when we set 'post_status' => 'any-string', it still shows private posts.


Need to check each post with `current_user_can()` function.

For password protected posts, user can still read the title so it should return data and it isn't bug.