### PR TITLE
Replace sprintf with String Concatenation in RWMB_Field::show

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -40,7 +40,7 @@ abstract class RWMB_Field {
 		$end = static::end_html( $field );
 		$end = self::filter( 'end_html', $end, $field, $meta );
 
-		$html = self::filter('wrapper_html', $begin . $field_html . $end, $field, $meta);
+		$html = self::filter( 'wrapper_html', $begin . $field_html . $end, $field, $meta );
 
 		// Display label and input in DIV and allow user-defined classes to be appended.
 		$classes = "rwmb-field rwmb-{$field['type']}-wrapper " . $field['class'];
@@ -48,12 +48,12 @@ abstract class RWMB_Field {
 			$classes .= ' required';
 		}
 
-		$classes = esc_attr(trim($classes));
+		$classes = esc_attr( trim( $classes ) );
 
-		$outer_html = $field['before'];
+		$outer_html  = $field['before'];
 		$outer_html .= '<div class="' . $classes . '">' . $html . '</div>';
 		$outer_html .= $field['after'];
-		
+
 		$outer_html = self::filter( 'outer_html', $outer_html, $field, $meta );
 
 		echo $outer_html; // phpcs:ignore WordPress.Security.EscapeOutput

--- a/inc/field.php
+++ b/inc/field.php
@@ -40,7 +40,7 @@ abstract class RWMB_Field {
 		$end = static::end_html( $field );
 		$end = self::filter( 'end_html', $end, $field, $meta );
 
-		$html = self::filter( 'wrapper_html', "$begin$field_html$end", $field, $meta );
+		$html = self::filter('wrapper_html', $begin . $field_html . $end, $field, $meta);
 
 		// Display label and input in DIV and allow user-defined classes to be appended.
 		$classes = "rwmb-field rwmb-{$field['type']}-wrapper " . $field['class'];
@@ -48,11 +48,12 @@ abstract class RWMB_Field {
 			$classes .= ' required';
 		}
 
-		$outer_html = sprintf(
-			$field['before'] . '<div class="%s">%s</div>' . $field['after'],
-			esc_attr( trim( $classes ) ),
-			$html
-		);
+		$classes = esc_attr(trim($classes));
+
+		$outer_html = $field['before'];
+		$outer_html .= '<div class="' . $classes . '">' . $html . '</div>';
+		$outer_html .= $field['after'];
+		
 		$outer_html = self::filter( 'outer_html', $outer_html, $field, $meta );
 
 		echo $outer_html; // phpcs:ignore WordPress.Security.EscapeOutput


### PR DESCRIPTION
## Summary
Resolve issues arising from the use of sprintf which led to fatal errors when handling special characters like `%` in field contents.

## Changes:
1. Removed `sprintf`:
- Replaced with direct string concatenation to enhance control and prevent format specifier errors.
2. Escaping and Concatenation:
- Escaped class attributes using esc_attr to ensure security.
- Concatenated strings directly to form the final HTML output, ensuring that special characters in dynamic content do not disrupt the output.

## Files Affected:
Prior implementation using sprintf caused fatal errors when special characters interfered with format specifiers.

Direct string concatenation mitigates these issues, providing a more robust method for generating HTML while maintaining the ability to filter content at various stages.

## Testing:
Manually tested with titles containing special characters to confirm that errors are resolved. Ensured that visual output and functionality align with expectations in various test scenarios.