### PR TITLE
fix: subfield's id

### DIFF
--- a/inc/clone.php
+++ b/inc/clone.php
@@ -10,13 +10,14 @@ class RWMB_Clone {
 		foreach ( $meta as $index => $sub_meta ) {
 			$sub_field               = $field;
 			$sub_field['field_name'] = $field['field_name'] . "[{$index}]";
+			$attributes_id = $sub_field['attributes']['id'] ?? $sub_field['id'];
 
 			if ( $index === 0 && $count > 1 ) {
-				$sub_field['attributes']['id'] = $field['id'] . "_rwmb_template";
+				$sub_field['attributes']['id'] = $attributes_id . "_rwmb_template";
 			}
 
 			if ( $index === 1 ) {
-				$sub_field['attributes']['id'] = $field['id'];
+				$sub_field['attributes']['id'] = $attributes_id;
 			}
 
 			if ( $index > 1 ) {


### PR DESCRIPTION
Bản update trước, trường hợp clone index = 0 (template) hoặc 1 (original id) thì mình sẽ khai báo bằng `$field['id'] . _rwmb_template` hoặc `$field[id]`.

Tuy nhiên, làm vậy chưa đúng với trường hợp cả group + subfield đều clone, như vậy nó sẽ trở thành:

- groupId_template
-- subfieldId_rwmb_template
-- subfieldId
- groupId
-- subfieldId_rwmb_template
-- subfieldId

Như vậy là bị trùng lặp ID dẫn đến wysiwyg init bị sai.

Cách sửa là ta dùng $field['attributes']['id'] thay vì $field['id'] vì trong group mình đã xử lý phần này tốt rồi. 

