### PR TITLE
feat: validation for taxonomies

### DIFF
--- a/js/validation/validation.js
+++ b/js/validation/validation.js
@@ -225,8 +225,8 @@
 		init() {
 			var that = this,
 				editor = wp.data.dispatch( 'core/editor' );
-			
-			if ( ! editor || ! that.$form.length ) {
+
+			if ( !editor || !that.$form.length ) {
 				return false;
 			}
 
@@ -258,6 +258,25 @@
 		}
 	};
 
+	class TaxonomyValidation extends Validation {
+		init() {
+			const submitButton = $( '#submit' );
+
+			this.$form.validate( {
+				...this.settings, 
+				invalidHandler: null,
+				onkeyup: () => {
+					submitButton.prop( 'disabled', ! this.$form.valid() );
+				}
+			} );
+
+			submitButton.prop( 'disabled', ! this.$form.valid() );
+			$( '#tag-name' ).on( 'blur', () => {
+				submitButton.prop('disabled', ! this.$form.valid());
+			});
+		}
+	}
+
 	// Run on document ready.
 	function init() {
 		if ( rwmb.isGutenberg ) {
@@ -268,7 +287,7 @@
 			} );
 
 			new GutenbergValidation( `.mb-block-edit` ).init();
-			
+
 			return;
 		}
 
@@ -278,6 +297,14 @@
 			var form = new Validation( this );
 			form.init();
 		} );
+
+		const $addTag = $( '#addtag' );
+		if ( $addTag.length ) {
+			new TaxonomyValidation( '#addtag' ).init();
+			$( '#submit' ).on('click', function() {
+				new TaxonomyValidation( '#addtag' ).init();
+			});
+		}
 	};
 
 	rwmb.$document

--- a/js/validation/validation.js
+++ b/js/validation/validation.js
@@ -263,17 +263,17 @@
 			const submitButton = $( '#submit' );
 
 			this.$form.validate( {
-				...this.settings, 
+				...this.settings,
 				invalidHandler: null,
 				onkeyup: () => {
-					submitButton.prop( 'disabled', ! this.$form.valid() );
+					submitButton.prop( 'disabled', !this.$form.valid() );
 				}
 			} );
 
-			submitButton.prop( 'disabled', ! this.$form.valid() );
+			submitButton.prop( 'disabled', !this.$form.valid() );
 			$( '#tag-name' ).on( 'blur', () => {
-				submitButton.prop('disabled', ! this.$form.valid());
-			});
+				submitButton.prop( 'disabled', !this.$form.valid() );
+			} );
 		}
 	}
 
@@ -301,9 +301,9 @@
 		const $addTag = $( '#addtag' );
 		if ( $addTag.length ) {
 			new TaxonomyValidation( '#addtag' ).init();
-			$( '#submit' ).on('click', function() {
+			$( '#submit' ).on( 'click', function () {
 				new TaxonomyValidation( '#addtag' ).init();
-			});
+			} );
 		}
 	};
 


### PR DESCRIPTION
By default, our validation prevents form submitting using onsubmit event, but WP use button.onclick event so validation doesnt work for taxonomy form.

This PR add the ability to disable Add New Taxonomy button until the form is validated.