### PR TITLE
fix: max clone with clone empty start

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -86,8 +86,8 @@ abstract class RWMB_Field {
 			static::label_description( $field )
 		) : '';
 
-		$data_min_clone   = is_numeric( $field['min_clone'] ) && $field['min_clone'] > 1 ? ' data-min-clone=' . $field['min_clone'] : '';
-		$data_max_clone   = is_numeric( $field['max_clone'] ) && $field['max_clone'] > 1 ? ' data-max-clone=' . $field['max_clone'] : '';
+		$data_max_clone   = is_numeric( $field['max_clone'] ) ? ' data-max-clone=' . $field['max_clone'] : '';
+		$data_min_clone   = is_numeric( $field['min_clone'] ) ? ' data-min-clone=' . $field['min_clone'] : '';
 		$data_empty_start = $field['clone_empty_start'] ? ' data-clone-empty-start="1"' : ' data-clone-empty-start="0"';
 
 		$input_open = sprintf(
@@ -330,10 +330,6 @@ abstract class RWMB_Field {
 				'data-default'       => $field['std'],
 				'data-clone-default' => 'true',
 			] );
-		}
-
-		if ( 1 === $field['max_clone'] ) {
-			$field['clone'] = false;
 		}
 
 		return $field;


### PR DESCRIPTION
Previous version, if max clone = 1, then we remove clone attribute and treat as noncloneable field.

But when clone empty start = true, we should support max clone = 1, since it starts with zero field.

This commit fixes that issue.

Tested with clone and not clone field, clone empty start and not empty start field.

https://app.asana.com/0/1204192622667775/1209132788111951