### PR TITLE
fix: min max clone from builder

### DIFF
--- a/inc/field.php
+++ b/inc/field.php
@@ -86,8 +86,8 @@ abstract class RWMB_Field {
 			static::label_description( $field )
 		) : '';
 
-		$data_max_clone   = is_numeric( $field['max_clone'] ) ? ' data-max-clone=' . $field['max_clone'] : '';
-		$data_min_clone   = is_numeric( $field['min_clone'] ) ? ' data-min-clone=' . $field['min_clone'] : '';
+		$data_max_clone   = is_numeric( $field['max_clone'] ) && $field['max_clone'] > 0 ? ' data-max-clone=' . $field['max_clone'] : '';
+		$data_min_clone   = is_numeric( $field['min_clone'] ) && $field['min_clone'] > 0 ? ' data-min-clone=' . $field['min_clone'] : '';
 		$data_empty_start = $field['clone_empty_start'] ? ' data-clone-empty-start="1"' : ' data-clone-empty-start="0"';
 
 		$input_open = sprintf(


### PR DESCRIPTION
The previous PR added support max_clone = 1, to do that, I removed $field['max_clone'] = 1 check
https://github.com/wpmetabox/meta-box/commit/263fd9a7f13e79dfdb57a3a6e1538b642f83246a

But the data from the builder is always has max_clone = 0 by default, so `is_numeric( $field['max_clone'] )` is always true, therefore the html always printed out `data-max-clone=0` by default.

Thats why we always capped the limit, and the clone button doesnt show up.

Related: https://app.asana.com/0/inbox/1204192622667771/1209433895846414/1209434040753534


