### PR TITLE
Fix get_current_screen() error for term meta

### DIFF
--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -78,7 +78,12 @@ class RW_Meta_Box {
 	protected function global_hooks() {
 		// Enqueue common styles and scripts.
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+
+		// Enqueue assets for the block editor only, just for previewing (submission forms, custom blocks).
+		// Don't enqueue on frontend as front-end forms and blocks already call the enqueue() method.
+		if ( is_admin() ) {
+			add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+		}
 
 		// Add additional actions for fields.
 		foreach ( $this->fields as $field ) {

--- a/inc/meta-box.php
+++ b/inc/meta-box.php
@@ -81,9 +81,10 @@ class RW_Meta_Box {
 
 		// Enqueue assets for the block editor only, just for previewing (submission forms, custom blocks).
 		// Don't enqueue on frontend as front-end forms and blocks already call the enqueue() method.
-		if ( is_admin() ) {
-			add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
-		}
+		// TODO: Uncomment this when we have a way to enqueue assets for the block/site editor.
+		// if ( is_admin() ) {
+		// 	add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+		// }
 
 		// Add additional actions for fields.
 		foreach ( $this->fields as $field ) {


### PR DESCRIPTION
The problem is `RW_Meta_Box::enqueue()` is called on the frontend via `enqueue_block_assets` action, which checks the current screen. In term meta's `MetaBox.php` class, `get_current_screen()` is not available (as it's for admin only).

This fix makes the `enqueue_block_assets` hook runs only in the admin, as its purpose is for previewing front-end forms and blocks. And both front-end forms and blocks already call the `enqueue()` method on the front end, so no need to hook to run it on the front end.