### PR TITLE
WPML integration: filter the helper function to get the translated value

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,8 @@
 /* Styles for 'normal' meta boxes
 -------------------------------------------------------------- */
 
-/* Clearfix for field */
-.rwmb-field {
+/* Lower specificity so it field classes are applied */
+:where(.rwmb-field) {
 	display: flex;
 }
 .rwmb-field:not(:last-of-type) {

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -96,10 +96,6 @@ class RWMB_Loader {
 		$media_modal = new RWMB_Media_Modal();
 		$media_modal->init();
 
-		// WPML Compatibility.
-		$wpml = new RWMB_WPML();
-		$wpml->init();
-
 		// Update.
 		$update_option  = null;
 		$update_checker = null;
@@ -112,6 +108,9 @@ class RWMB_Loader {
 			$update_notification = new \MetaBox\Updater\Notification( $update_checker, $update_option );
 			$update_notification->init();
 		}
+
+		// WPML Compatibility.
+		new \MetaBox\Integrations\WPML();
 
 		// Register categories for page builders.
 		new \MetaBox\Integrations\Block();

--- a/src/Integrations/WPML.php
+++ b/src/Integrations/WPML.php
@@ -20,6 +20,9 @@ class WPML {
 		}
 		add_filter( 'wpml_duplicate_generic_string', [ $this, 'translate_ids' ], 10, 3 );
 		add_filter( 'rwmb_normalize_field', [ $this, 'modify_field' ] );
+
+		// Filter the value on the front end.
+		add_filter( 'rwmb_get_value', [ $this, 'get_translated_value' ], 10, 4 );
 	}
 
 	/**
@@ -101,5 +104,21 @@ class WPML {
 		}
 
 		return $field;
+	}
+
+	public function get_translated_value( $value, $field ) {
+		if ( ! $field || empty( $value ) || ! is_numeric( $value ) ) {
+			return $value;
+		}
+
+		if ( ! in_array( $field['type'], $this->field_types, true ) ) {
+			return $value;
+		}
+
+		$type             = 'post' === $field['type'] ? reset( $field['post_type'] ) : reset( $field['taxonomy'] );
+		$current_language = apply_filters( 'wpml_current_language', null );
+		$value            = apply_filters( 'wpml_object_id', $value, $type, true, $current_language );
+
+		return $value;
 	}
 }

--- a/src/Integrations/WPML.php
+++ b/src/Integrations/WPML.php
@@ -1,25 +1,20 @@
 <?php
-/**
- * The WPML compatibility module, allowing all fields are translatable by WPML plugin.
- */
-class RWMB_WPML {
+namespace MetaBox\Integrations;
+
+class WPML {
 	/**
 	 * List of fields that need to translate values (because they're saved as IDs).
 	 *
 	 * @var array
 	 */
-	protected $field_types = [ 'post', 'taxonomy_advanced' ];
+	private $field_types = [ 'post', 'taxonomy_advanced' ];
 
-	public function init() {
-		/**
-		 * Run before meta boxes are registered so it can modify fields.
-		 *
-		 * @see modify_field()
-		 */
-		add_action( 'init', [ $this, 'register_hooks' ], 9 );
+	public function __construct() {
+		// Run before meta boxes are registered (at `init` with priority 20) so it can modify fields.
+		add_action( 'init', [ $this, 'init' ] );
 	}
 
-	public function register_hooks() {
+	public function init(): void {
 		if ( ! defined( 'ICL_SITEPRESS_VERSION' ) ) {
 			return;
 		}
@@ -72,12 +67,8 @@ class RWMB_WPML {
 	 * - Do not translate: hide the field.
 	 * - Copy: make it disabled so users cannot edit.
 	 * - Translate: do nothing.
-	 *
-	 * @param array $field Field parameters.
-	 *
-	 * @return mixed
 	 */
-	public function modify_field( $field ) {
+	public function modify_field( array $field ): array {
 		global $wpml_post_translations;
 
 		if ( empty( $field['id'] ) ) {


### PR DESCRIPTION
Now when using helper functions to get values of `post` and/or `taxonomy_advanced` fields, the returned value will be translated ID(s).