### PR TITLE
Add link field with native wpLink integration

### DIFF
--- a/css/link.css
+++ b/css/link.css
@@ -1,7 +1,3 @@
-.rwmb-link {
-	padding: 5px 0;
-}
-
 .rwmb-link-display {
 	display: flex;
 	align-items: center;
@@ -10,15 +6,17 @@
 
 .rwmb-link-text {
 	flex: 1;
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .rwmb-link-text .dashicons {
 	color: #999;
 	vertical-align: middle;
-}
-
-.rwmb-link-text a {
-	text-decoration: underline;
+	font-size: 16px;
+	width: 1em;
+	height: 1em;
 }
 
 .rwmb-link-target {

--- a/css/link.css
+++ b/css/link.css
@@ -1,0 +1,36 @@
+.rwmb-link {
+	padding: 5px 0;
+}
+
+.rwmb-link-display {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.rwmb-link-text {
+	flex: 1;
+}
+
+.rwmb-link-text .dashicons {
+	color: #999;
+	vertical-align: middle;
+}
+
+.rwmb-link-text a {
+	text-decoration: underline;
+}
+
+.rwmb-link-target {
+	color: #999;
+	font-style: italic;
+}
+
+.rwmb-link-edit,
+.rwmb-link-remove {
+	text-decoration: none;
+}
+
+.rwmb-link-select {
+	text-decoration: none;
+}

--- a/docs/superpowers/plans/2026-03-30-link-field-implementation.md
+++ b/docs/superpowers/plans/2026-03-30-link-field-implementation.md
@@ -1,0 +1,476 @@
+# Link Field Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- []`) syntax for tracking.
+
+**Goal:** Add a dedicated `link` field type to Meta Box that wraps WordPress's native Insert Link popup (`wpLink`), providing ACF-compatible UX for selecting internal posts or entering custom URLs with title and target support.
+
+**Architecture:** A new `RWMB_Link_Field` class extending `RWMB_Field`. Renders hidden inputs for url/title/target/post_id plus a visible display area with select/edit/remove buttons. JS wraps the WordPress `wpLink` API to open the native link dialog and populate hidden inputs. Saves as a single serialized post meta array. Front-end output via existing `rwmb_the_field()` / `rwmb_get_field()` helpers.
+
+**Tech Stack:** PHP (WordPress plugin), jQuery, wpLink API, CSS
+
+---
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| `inc/fields/link.php` | `RWMB_Link_Field` — field class (normalize, html, value, format) |
+| `js/link.js` | jQuery script — open wpLink, read results, populate hidden inputs |
+| `css/link.css` | Styling for empty/filled display states |
+| `tests/phpunit/LinkTest.php` | PHPUnit tests for value() and format_single_value() |
+
+---
+
+### Task 1: Create the PHP field class
+
+**Files:**
+- Create: `inc/fields/link.php`
+
+- [ ] **Step 1: Create the file with class skeleton**
+
+Create `inc/fields/link.php`:
+
+```php
+<?php
+defined( 'ABSPATH' ) || die;
+
+/**
+ * The link field.
+ */
+class RWMB_Link_Field extends RWMB_Field {
+	public static function admin_enqueue_scripts() {
+		wp_enqueue_style( 'rwmb-link', RWMB_CSS_URL . 'link.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-link', 'path', RWMB_CSS_DIR . 'link.css' );
+		wp_enqueue_script( 'rwmb-link', RWMB_JS_URL . 'link.js', ['jquery'], RWMB_VER, true );
+		wp_enqueue_editor();
+	}
+
+	public static function html( $meta, $field ) {
+		$meta = wp_parse_args( $meta, [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		] );
+
+		$name = $field['field_name'];
+
+		$output  = '<div class="rwmb-link" data-field-name="' . esc_attr( $name ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[url]" value="' . esc_attr( $meta['url'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[title]" value="' . esc_attr( $meta['title'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[target]" value="' . esc_attr( $meta['target'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[post_id]" value="' . esc_attr( $meta['post_id'] ) . '">';
+
+		if ( $meta['url'] ) {
+			$output .= '<div class="rwmb-link-display">';
+			$output .= '<span class="rwmb-link-text">';
+			$output .= '<span class="dashicons dashicons-admin-links"></span> ';
+			$output .= '<a href="' . esc_url( $meta['url'] ) . '" target="_blank">' . esc_html( $meta['title'] ) . '</a>';
+			if ( '_blank' === $meta['target'] ) {
+				$output .= ' <span class="rwmb-link-target">' . esc_html__( '(new tab)', 'meta-box' ) . '</span>';
+			}
+			$output .= '</span> ';
+			$output .= '<a href="#" class="rwmb-link-edit">' . esc_html__( 'Edit', 'meta-box' ) . '</a>';
+			$output .= ' | ';
+			$output .= '<a href="#" class="rwmb-link-remove">' . esc_html__( 'Remove', 'meta-box' ) . '</a>';
+			$output .= '</div>';
+		} else {
+			$output .= '<div class="rwmb-link-display">';
+			$output .= '<a href="#" class="rwmb-link-select button">' . esc_html__( 'Select link', 'meta-box' ) . '</a>';
+			$output .= '</div>';
+		}
+
+		$output .= '</div>';
+
+		return $output;
+	}
+
+	public static function normalize( $field ) {
+		$field             = parent::normalize( $field );
+		$field['multiple'] = false;
+		return $field;
+	}
+
+	public static function value( $new, $old, $post_id, $field ) {
+		$new = wp_parse_args( $new, [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		] );
+
+		$new['url']     = esc_url_raw( $new['url'] );
+		$new['title']   = wp_kses_post( $new['title'] );
+		$new['target']  = in_array( $new['target'], ['_blank', ''], true ) ? $new['target'] : '';
+		$new['post_id'] = absint( $new['post_id'] );
+
+		$all_empty = empty( $new['url'] ) && empty( $new['title'] ) && empty( $new['post_id'] );
+		return $all_empty ? [] : $new;
+	}
+
+	public static function format_single_value( $field, $value, $args, $post_id ) {
+		if ( empty( $value['url'] ) ) {
+			return '';
+		}
+		$url    = esc_url( $value['url'] );
+		$title  = esc_html( $value['title'] );
+		$target = ! empty( $value['target'] ) ? ' target="' . esc_attr( $value['target'] ) . '"' : '';
+		return '<a href="' . $url . '"' . $target . '>' . $title . '</a>';
+	}
+
+	public static function format_value( $field, $value, $args, $post_id ) {
+		if ( ! $field['clone'] ) {
+			return self::format_single_value( $field, $value, $args, $post_id );
+		}
+
+		$output = '';
+		foreach ( $value as $subvalue ) {
+			$output .= self::format_single_value( $field, $subvalue, $args, $post_id ) . "\n";
+		}
+		return $output;
+	}
+}
+```
+
+- [ ] **Step 2: Verify autoloader picks up the field**
+
+The autoloader at `inc/autoloader.php` maps `RWMB_{TitleCase}_Field` to `inc/fields/{lowercase-hyphenated}.php`. So `RWMB_Link_Field` → `inc/fields/link.php`. No changes needed.
+
+Verify by checking: does the autoloader have the prefix/suffix pattern? (Yes — `RWMB_` prefix, `_Field` suffix, `inc/fields/` directory.)
+
+---
+
+### Task 2: Create the JavaScript
+
+**Files:**
+- Create: `js/link.js`
+
+- [ ] **Step 1: Write `js/link.js`**
+
+```js
+( function( $, wpLink ) {
+	'use strict';
+
+	$( document ).on( 'click', '.rwmb-link-select, .rwmb-link-edit', function( e ) {
+		e.preventDefault();
+
+		var $link  = $( this ).closest( '.rwmb-link' ),
+			$url   = $link.find( 'input[name$="[url]"]' ),
+			$title = $link.find( 'input[name$="[title]"]' ),
+			$target = $link.find( 'input[name$="[target]"]' );
+
+		wpLink.open( 'rwmb-link-wp-editor', $url.val(), $target.val() === '_blank' ? '1' : '', $title.val() );
+
+		// Close handler to capture link.
+		$( '#wp-link-submit' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', function() {
+			var attrs = wpLink.getAttrs();
+			if ( ! attrs.href ) {
+				return;
+			}
+
+			$url.val( attrs.href );
+			$title.val( $( '#wp-link-text' ).val() || attrs.href );
+			$target.val( attrs.target === '_blank' ? '_blank' : '' );
+
+			// Try to extract post_id from wpLink internal data.
+			var postData = $( '#wp-link-wrap' ).data( 'selectedPost' );
+			$link.find( 'input[name$="[post_id]"]' ).val( postData && postData.ID ? postData.ID : 0 );
+
+			// Update display.
+			var name = $link.data( 'field-name' ),
+				titleVal = $title.val(),
+				targetVal = $target.val(),
+				display = '';
+
+			display += '<span class="rwmb-link-text">';
+			display += '<span class="dashicons dashicons-admin-links"></span> ';
+			display += '<a href="' + attrs.href + '" target="_blank">' + titleVal + '</a>';
+			if ( targetVal === '_blank' ) {
+				display += ' <span class="rwmb-link-target">(new tab)</span>';
+			}
+			display += '</span> ';
+			display += '<a href="#" class="rwmb-link-edit">Edit</a> | ';
+			display += '<a href="#" class="rwmb-link-remove">Remove</a>';
+
+			$link.find( '.rwmb-link-display' ).html( display );
+			wpLink.close();
+		} );
+
+		$( '#wp-link-cancel' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', function() {
+			wpLink.close();
+		} );
+	} );
+
+	$( document ).on( 'click', '.rwmb-link-remove', function( e ) {
+		e.preventDefault();
+
+		var $link = $( this ).closest( '.rwmb-link' );
+		$link.find( 'input[name$="[url]"]' ).val( '' );
+		$link.find( 'input[name$="[title]"]' ).val( '' );
+		$link.find( 'input[name$="[target]"]' ).val( '' );
+		$link.find( 'input[name$="[post_id]"]' ).val( 0 );
+		$link.find( '.rwmb-link-display' ).html( '<a href="#" class="rwmb-link-select button">Select link</a>' );
+	} );
+
+} )( jQuery, wpLink );
+```
+
+- [ ] **Step 2: Verify wpLink API**
+
+Research the WordPress wpLink API:
+- `wpLink.open( editorId, url, target, title )` — opens the modal pre-filled
+- `wpLink.getAttrs()` — returns `{ href, target, title }` after submission
+- `wpLink.close()` — closes the modal
+
+The `editorId` parameter is used internally by wpLink — we pass a unique ID so it doesn't conflict with the post editor's link dialog.
+
+- [ ] **Step 3: Test post_id extraction**
+
+The wpLink modal internally tracks selected post data. The approach is:
+- When a post is selected in the link search, wpLink stores it in `$('#wp-link-wrap').data('selectedPost')`
+- If that's not available, fall back to `0` (custom URL)
+- This may need adjustment during implementation if the internal API differs across WP versions
+
+---
+
+### Task 3: Create the CSS
+
+**Files:**
+- Create: `css/link.css`
+
+- [ ] **Step 1: Write `css/link.css`**
+
+```css
+.rwmb-link {
+	padding: 5px 0;
+}
+
+.rwmb-link-display {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.rwmb-link-text {
+	flex: 1;
+}
+
+.rwmb-link-text .dashicons {
+	color: #999;
+	vertical-align: middle;
+}
+
+.rwmb-link-text a {
+	text-decoration: underline;
+}
+
+.rwmb-link-target {
+	color: #999;
+	font-style: italic;
+}
+
+.rwmb-link-edit,
+.rwmb-link-remove {
+	text-decoration: none;
+}
+
+.rwmb-link-select {
+	text-decoration: none;
+}
+```
+
+---
+
+### Task 4: Write PHPUnit tests
+
+**Files:**
+- Create: `tests/phpunit/LinkTest.php`
+
+- [ ] **Step 1: Create test file**
+
+Create `tests/phpunit/LinkTest.php`:
+
+```php
+<?php
+class LinkTest extends WP_UnitTestCase {
+	public function testNormalize() {
+		$field = RWMB_Link_Field::normalize( [
+			'type' => 'link',
+			'id'   => 'my_link',
+			'name' => 'My Link',
+		] );
+
+		$this->assertFalse( $field['multiple'] );
+		$this->assertEquals( 'link', $field['type'] );
+	}
+
+	public function testValueSanitizes() {
+		$new = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '_blank',
+			'post_id' => '42',
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( 'https://example.com/test', $result['url'] );
+		$this->assertEquals( 'Test Link', $result['title'] );
+		$this->assertEquals( '_blank', $result['target'] );
+		$this->assertEquals( 42, $result['post_id'] );
+	}
+
+	public function testValueReturnsEmptyForEmptyInputs() {
+		$new = [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( [], $result );
+	}
+
+	public function testValueRejectsInvalidTarget() {
+		$new = [
+			'url'     => 'https://example.com',
+			'title'   => 'Link',
+			'target'  => 'invalid',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( '', $result['target'] );
+	}
+
+	public function testFormatSingleValue() {
+		$value = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '_blank',
+			'post_id' => 42,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '<a href="https://example.com/test" target="_blank">Test Link</a>', $result );
+	}
+
+	public function testFormatSingleValueNoTarget() {
+		$value = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '<a href="https://example.com/test">Test Link</a>', $result );
+	}
+
+	public function testFormatSingleValueEmptyUrl() {
+		$value = [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '', $result );
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `./vendor/bin/phpunit tests/phpunit/LinkTest.php`
+
+Expected: All tests pass.
+
+---
+
+### Task 5: Verify lint and static analysis
+
+- [ ] **Step 1: Run PHPCS**
+
+Run: `composer phpcs`
+
+Expected: No errors on the new files. Fix any coding standard issues (indentation, spacing, docblocks).
+
+- [ ] **Step 2: Run PHPStan**
+
+Run: `composer phpstan`
+
+Expected: No new errors. (PHPStan only analyzes `inc/` directory.)
+
+---
+
+### Task 6: Manual testing
+
+- [ ] **Step 1: Test in WordPress admin**
+
+1. Register a link field in a test meta box:
+   ```php
+   add_filter( 'rwmb_meta_boxes', function( $meta_boxes ) {
+       $meta_boxes[] = [
+           'title'  => 'Test Link Field',
+           'fields' => [
+               [
+                   'type' => 'link',
+                   'id'   => 'test_link',
+                   'name' => 'Test Link',
+               ],
+               [
+                   'type'  => 'link',
+                   'id'    => 'test_link_cloned',
+                   'name'  => 'Test Link (Cloned)',
+                   'clone' => true,
+               ],
+           ],
+       ];
+       return $meta_boxes;
+   } );
+   ```
+
+2. Edit a post and verify:
+   - "Select link" button appears for empty fields
+   - Clicking opens the native WP link popup
+   - Selecting a post fills URL, title, and post_id
+   - Entering a custom URL works
+   - "Open in new tab" checkbox sets target to `_blank`
+   - Edit button pre-fills the modal
+   - Remove button clears the field
+   - Clone add/remove works correctly
+
+3. Save the post and verify:
+   - Values persist after save
+   - Values display correctly on reload
+
+- [ ] **Step 2: Test front-end helpers**
+
+In theme template:
+```php
+$link = rwmb_get_field( 'test_link' );
+var_dump( $link ); // Should show array with url, title, target, post_id
+
+rwmb_the_field( 'test_link' ); // Should render <a> tag
+```
+
+Verify correct output for both post-linked and custom URL cases.
+
+---
+
+### Task 7: Final commit
+
+- [ ] **Step 1: Commit all files**
+
+```bash
+git add inc/fields/link.php js/link.js css/link.css tests/phpunit/LinkTest.php
+git commit -m "feat: add link field type with native wpLink integration"
+```

--- a/docs/superpowers/specs/2026-03-30-link-field-design.md
+++ b/docs/superpowers/specs/2026-03-30-link-field-design.md
@@ -1,0 +1,234 @@
+# Link Field Design
+
+## Summary
+
+Add a dedicated `link` field type to Meta Box that provides a polished, ACF-compatible UX for selecting links. The field uses WordPress's native Insert Link popup (`wpLink`) to let content editors search for internal posts or enter custom URLs, with title and "open in new tab" support — all through a single, familiar interface.
+
+## Motivation
+
+Currently, achieving ACF-like link functionality in Meta Box requires combining multiple fields (a select for post-vs-URL, a post field, a URL field, a text field for title, a checkbox for target) with conditional logic. This is:
+
+- Time-consuming to configure per project
+- Produces non-uniform saved data (different shapes for post vs URL)
+- Provides a fragmented editing experience
+
+A dedicated link field eliminates this friction entirely.
+
+## Design Decisions
+
+**UI approach:** Reuse WordPress's native Insert Link popup (`wpLink`), identical to how ACF does it. No custom autocomplete, no modal — just wrapping the built-in component that content editors already know.
+
+**Data storage:** Single serialized post meta row per field instance. Static save (title/URL frozen at save time, not dynamically resolved). Includes `post_id` when a post is selected for advanced use cases.
+
+**Clone support:** Full support via Meta Box's existing `RWMB_Clone` mechanism.
+
+## Saved Data Format
+
+Single meta row (or per-clone index), serialized array:
+
+```php
+[
+    'url'     => 'https://example.com/my-page',  // Always populated
+    'title'   => 'My Page Title',                 // Always populated
+    'target'  => '_blank',                        // '_blank' or '' (empty = same tab)
+    'post_id' => 42,                              // 0 if custom URL
+]
+```
+
+## Field Configuration
+
+```php
+[
+    'type'  => 'link',
+    'id'    => 'hero_link',
+    'name'  => 'Hero Link',
+    'clone' => true,  // Optional, defaults to false
+]
+```
+
+Minimal config. No `post_types` option needed — WordPress's native link popup searches all public post types by default.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `inc/fields/link.php` | `RWMB_Link_Field` class |
+| `js/link.js` | wpLink integration JS |
+| `css/link.css` | Field display styling |
+
+## PHP Class: `RWMB_Link_Field extends RWMB_Field`
+
+### `normalize( $field )`
+
+- Call `parent::normalize( $field )`
+- Set `multiple => false` (composite field, not multi-value)
+- Return normalized field
+
+### `admin_enqueue_scripts()`
+
+- Enqueue `link.css` with `wp_enqueue_style()`
+- Enqueue `link.js` with `wp_enqueue_script()`, depends on `['jquery']`
+- Call `wp_enqueue_editor()` to ensure wpLink JS is loaded
+- No localized data needed (wpLink is globally available)
+
+### `html( $meta, $field )`
+
+Render a container with:
+
+1. Hidden inputs for each sub-value (using bracket notation):
+   - `<input type="hidden" name="field_name[url]" value="...">`
+   - `<input type="hidden" name="field_name[title]" value="...">`
+   - `<input type="hidden" name="field_name[target]" value="...">`
+   - `<input type="hidden" name="field_name[post_id]" value="...">`
+
+2. A visible display area (`.rwmb-link-display`):
+   - Empty state: "Select link" button (triggers wpLink)
+   - Filled state: clickable link text with "(opens in new tab)" indicator, plus Edit and Remove buttons
+
+3. The container holds `data-field-name` attribute for JS to construct hidden input names when updating values from the wpLink dialog.
+
+HTML structure (empty state):
+```html
+<div class="rwmb-link" data-field-name="my_field">
+    <input type="hidden" name="my_field[url]" value="">
+    <input type="hidden" name="my_field[title]" value="">
+    <input type="hidden" name="my_field[target]" value="">
+    <input type="hidden" name="my_field[post_id]" value="0">
+    <div class="rwmb-link-display">
+        <a href="#" class="rwmb-link-select button">Select link</a>
+    </div>
+</div>
+```
+
+HTML structure (filled state):
+```html
+<div class="rwmb-link" data-field-name="my_field">
+    <input type="hidden" name="my_field[url]" value="https://example.com/my-page">
+    <input type="hidden" name="my_field[title]" value="My Page Title">
+    <input type="hidden" name="my_field[target]" value="_blank">
+    <input type="hidden" name="my_field[post_id]" value="42">
+    <div class="rwmb-link-display">
+        <span class="rwmb-link-text">
+            <span class="dashicons dashicons-admin-links"></span>
+            <a href="https://example.com/my-page" target="_blank">My Page Title</a>
+            <span class="rwmb-link-target"> (new tab)</span>
+        </span>
+        <a href="#" class="rwmb-link-edit">Edit</a> |
+        <a href="#" class="rwmb-link-remove">Remove</a>
+    </div>
+</div>
+```
+
+### `value( $new, $old, $post_id, $field )`
+
+- Sanitize: `wp_kses_post()` on title, `esc_url_raw()` on url, `absint()` on post_id, restrict target to `['_blank', '']`
+- If all sub-values are empty/zero, return `[]` (delete meta)
+- Return sanitized array
+
+### `format_single_value( $field, $value, $args, $post_id )`
+
+Render an `<a>` tag:
+```php
+$url    = esc_url( $value['url'] );
+$title  = esc_html( $value['title'] );
+$target = ! empty( $value['target'] ) ? ' target="_blank"' : '';
+return "<a href=\"{$url}\"{$target}>{$title}</a>";
+```
+
+### `format_value( $field, $value, $args, $post_id )`
+
+Handle clone vs non-clone:
+- Non-clone: delegate to `format_single_value()`
+- Clone: loop and concatenate `format_single_value()` calls, separated by newlines
+
+## JavaScript: `js/link.js`
+
+jQuery plugin pattern matching existing Meta Box scripts:
+
+```js
+( function( $, wpLink ) {
+    // On click of "Select link" or "Edit" button:
+    // 1. wpLink.open( editorId )
+    // 2. In wpLink.getAttrs() callback:
+    //    - Read href, title, target
+    //    - Determine post_id: if href is internal, try to extract post ID
+    //      via wp_link_query or parse the permalink
+    //    - Update hidden inputs
+    //    - Update display HTML
+    // 3. On "Remove" button: clear hidden inputs, reset display to empty state
+} )( jQuery, wpLink );
+```
+
+Key behaviors:
+- Open wpLink modal on "Select link" or "Edit" click
+- Pre-fill modal with current values (set wpLink inputs before opening)
+- On submit: read `wpLink.getAttrs()`, populate hidden inputs, update display
+- On "Remove": clear all inputs and reset to empty state
+- Determine `post_id`: use the `post_id` stored in wpLink's internal data if available (the link dialog stores it when a post is selected). Fall back to `0` for custom URLs.
+
+## CSS: `css/link.css`
+
+Minimal styling:
+- `.rwmb-link` — container with padding
+- `.rwmb-link-display` — inline display, aligned with other fields
+- `.rwmb-link-text` — shows the link text and URL with a link icon
+- `.rwmb-link-edit`, `.rwmb-link-remove` — small action links
+- `.rwmb-link-target` — muted "(new tab)" indicator
+
+## Clone Support
+
+Works via existing `RWMB_Clone` mechanism. Each clone instance gets:
+- Indexed hidden inputs: `field_name[0][url]`, `field_name[1][url]`, etc.
+- Each clone has its own "Select link" / display / edit / remove buttons
+- JS uses the clone's `data-field-name` to construct correct input names
+
+## Front-End Usage
+
+```php
+// Raw array
+$link = rwmb_get_field( 'hero_link' );
+// ['url' => '...', 'title' => '...', 'target' => '_blank', 'post_id' => 42]
+
+// Formatted as <a> tag
+rwmb_the_field( 'hero_link' );
+// <a href="https://example.com/my-page" target="_blank">My Page Title</a>
+
+// Manual rendering with raw array
+$link = rwmb_get_field( 'hero_link' );
+if ( $link ) {
+    printf(
+        '<a href="%s" target="%s">%s</a>',
+        esc_url( $link['url'] ),
+        esc_attr( $link['target'] ?: '_self' ),
+        esc_html( $link['title'] )
+    );
+}
+
+// Resolve post_id for linked post
+$link = rwmb_get_field( 'hero_link' );
+if ( $link && $link['post_id'] ) {
+    $post = get_post( $link['post_id'] );
+    // Access post data directly
+}
+
+// Cloned links
+$links = rwmb_get_field( 'related_links' );
+foreach ( $links as $link ) {
+    printf( '<a href="%s" target="%s">%s</a>', ... );
+}
+```
+
+## Testing
+
+- Register a link field in a test meta box configuration
+- Verify "Select link" button opens the native WP link popup
+- Verify selecting a post auto-fills URL, title, and post_id
+- Verify entering a custom URL saves correctly with post_id = 0
+- Verify "open in new tab" checkbox sets target to `_blank`
+- Verify Edit button pre-fills the modal with current values
+- Verify Remove button clears the field
+- Verify clone support (add/remove/sort clones)
+- Verify `rwmb_get_field()` returns the array
+- Verify `rwmb_the_field()` renders `<a>` tag
+- Verify PHPStan (level 9) passes
+- Verify PHPCS passes with WordPress coding standards

--- a/inc/fields/link.php
+++ b/inc/fields/link.php
@@ -46,7 +46,7 @@ class RWMB_Link_Field extends RWMB_Field {
 			$output .= '<span class="dashicons dashicons-admin-links"></span> ';
 			$output .= '<a href="' . esc_url( $meta['url'] ) . '" target="_blank">' . esc_html( $meta['title'] ) . '</a>';
 			if ( '_blank' === $meta['target'] ) {
-				$output .= ' <span class="rwmb-link-target">' . esc_html__( '(new tab)', 'meta-box' ) . '</span>';
+				$output .= '<span class="rwmb-link-target">' . esc_html__( '(new tab)', 'meta-box' ) . '</span>';
 			}
 			$output .= '</span> ';
 			$output .= '<a href="#" class="rwmb-link-edit">' . esc_html__( 'Edit', 'meta-box' ) . '</a>';
@@ -54,7 +54,7 @@ class RWMB_Link_Field extends RWMB_Field {
 			$output .= '</div>';
 		} else {
 			$output .= '<div class="rwmb-link-display">';
-			$output .= '<button class="button rwmb-link-select">' . esc_html__( 'Add link', 'meta-box' ) . '</button>';
+			$output .= '<a href="#" class="rwmb-link-select">' . esc_html__( 'Add link', 'meta-box' ) . '</a>';
 			$output .= '</div>';
 		}
 

--- a/inc/fields/link.php
+++ b/inc/fields/link.php
@@ -1,0 +1,114 @@
+<?php
+defined( 'ABSPATH' ) || die;
+
+/**
+ * The link field.
+ */
+class RWMB_Link_Field extends RWMB_Field {
+	public static function admin_enqueue_scripts() {
+		wp_enqueue_style( 'rwmb-link', RWMB_CSS_URL . 'link.css', [], RWMB_VER );
+		wp_style_add_data( 'rwmb-link', 'path', RWMB_CSS_DIR . 'link.css' );
+		wp_enqueue_script( 'rwmb-link', RWMB_JS_URL . 'link.js', [ 'jquery' ], RWMB_VER, true );
+		wp_localize_script( 'rwmb-link', 'rwmbLink', [
+			'editText'       => esc_html__( 'Edit', 'meta-box' ),
+			'removeText'     => esc_html__( 'Remove', 'meta-box' ),
+			'newTabText'     => esc_html__( '(new tab)', 'meta-box' ),
+			'selectLinkText' => esc_html__( 'Add link', 'meta-box' ),
+		] );
+		wp_enqueue_editor();
+	}
+
+	/**
+	 * Get field HTML.
+	 *
+	 * @param mixed $meta  Meta value.
+	 * @param array $field Field settings.
+	 *
+	 * @return string
+	 */
+	public static function html( $meta, $field ) {
+		$meta = wp_parse_args( $meta, [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		] );
+
+		$name = $field['field_name'];
+
+		$output  = '<div class="rwmb-link" data-field-name="' . esc_attr( $name ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[url]" value="' . esc_attr( $meta['url'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[title]" value="' . esc_attr( $meta['title'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[target]" value="' . esc_attr( $meta['target'] ) . '">';
+		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[post_id]" value="' . esc_attr( $meta['post_id'] ) . '">';
+
+		if ( $meta['url'] ) {
+			$output .= '<div class="rwmb-link-display">';
+			$output .= '<span class="rwmb-link-text">';
+			$output .= '<span class="dashicons dashicons-admin-links"></span> ';
+			$output .= '<a href="' . esc_url( $meta['url'] ) . '" target="_blank">' . esc_html( $meta['title'] ) . '</a>';
+			if ( '_blank' === $meta['target'] ) {
+				$output .= ' <span class="rwmb-link-target">' . esc_html__( '(new tab)', 'meta-box' ) . '</span>';
+			}
+			$output .= '</span> ';
+			$output .= '<a href="#" class="rwmb-link-edit">' . esc_html__( 'Edit', 'meta-box' ) . '</a>';
+			$output .= '<a href="#" class="rwmb-link-remove">' . esc_html__( 'Remove', 'meta-box' ) . '</a>';
+			$output .= '</div>';
+		} else {
+			$output .= '<div class="rwmb-link-display">';
+			$output .= '<a href="#" class="rwmb-link-select">' . esc_html__( 'Add link', 'meta-box' ) . '</a>';
+			$output .= '</div>';
+		}
+
+		$output .= '</div>';
+
+		return $output;
+	}
+
+	/**
+	 * Set value of meta before saving into database.
+	 *
+	 * @param mixed $new     The submitted meta value.
+	 * @param mixed $old     The existing meta value.
+	 * @param int   $post_id The post ID.
+	 * @param array $field   The field parameters.
+	 *
+	 * @return mixed
+	 */
+	public static function value( $new, $old, $post_id, $field ) {
+		$new = wp_parse_args( $new, [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		] );
+
+		$new['url']     = esc_url_raw( $new['url'] );
+		$new['title']   = wp_kses_post( $new['title'] );
+		$new['target']  = in_array( $new['target'], [ '_blank', '' ], true ) ? $new['target'] : '';
+		$new['post_id'] = absint( $new['post_id'] );
+
+		$all_empty = empty( $new['url'] ) && empty( $new['title'] ) && empty( $new['post_id'] );
+		return $all_empty ? [] : $new;
+	}
+
+	/**
+	 * Format a single value for the helper functions.
+	 *
+	 * @param array    $field   Field parameters.
+	 * @param array    $value   The value.
+	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
+	 * @param int|null $post_id Post ID. null for current post. Optional.
+	 *
+	 * @return string
+	 */
+	public static function format_single_value( $field, $value, $args, $post_id ) {
+		if ( empty( $value['url'] ) ) {
+			return '';
+		}
+		$url    = esc_url( $value['url'] );
+		$title  = esc_html( $value['title'] );
+		$target = ! empty( $value['target'] ) ? ' target="' . esc_attr( $value['target'] ) . '"' : '';
+		return '<a href="' . $url . '"' . $target . '>' . $title . '</a>';
+	}
+}

--- a/inc/fields/link.php
+++ b/inc/fields/link.php
@@ -5,7 +5,7 @@ defined( 'ABSPATH' ) || die;
  * The link field.
  */
 class RWMB_Link_Field extends RWMB_Field {
-	public static function admin_enqueue_scripts() {
+	public static function admin_enqueue_scripts(): void {
 		wp_enqueue_style( 'rwmb-link', RWMB_CSS_URL . 'link.css', [], RWMB_VER );
 		wp_style_add_data( 'rwmb-link', 'path', RWMB_CSS_DIR . 'link.css' );
 		wp_enqueue_script( 'rwmb-link', RWMB_JS_URL . 'link.js', [ 'jquery' ], RWMB_VER, true );
@@ -23,10 +23,8 @@ class RWMB_Link_Field extends RWMB_Field {
 	 *
 	 * @param mixed $meta  Meta value.
 	 * @param array $field Field settings.
-	 *
-	 * @return string
 	 */
-	public static function html( $meta, $field ) {
+	public static function html( $meta, $field ): string {
 		$meta = wp_parse_args( $meta, [
 			'url'     => '',
 			'title'   => '',
@@ -99,16 +97,13 @@ class RWMB_Link_Field extends RWMB_Field {
 	 * @param array    $value   The value.
 	 * @param array    $args    Additional arguments. Rarely used. See specific fields for details.
 	 * @param int|null $post_id Post ID. null for current post. Optional.
-	 *
-	 * @return string
 	 */
-	public static function format_single_value( $field, $value, $args, $post_id ) {
-		if ( empty( $value['url'] ) ) {
-			return '';
-		}
-		$url    = esc_url( $value['url'] );
-		$title  = esc_html( $value['title'] );
-		$target = ! empty( $value['target'] ) ? ' target="' . esc_attr( $value['target'] ) . '"' : '';
-		return '<a href="' . $url . '"' . $target . '>' . $title . '</a>';
+	public static function format_single_value( $field, $value, $args, $post_id ): string {
+		return empty( $value['url'] ) ? '' : sprintf(
+			'<a href="%s"%s>%s</a>',
+			esc_url( $value['url'] ),
+			empty( $value['target'] ) ? '' : ' target="' . esc_attr( $value['target'] ) . '"',
+			esc_html( $value['title'] ?? '' )
+		);
 	}
 }

--- a/inc/fields/link.php
+++ b/inc/fields/link.php
@@ -8,7 +8,7 @@ class RWMB_Link_Field extends RWMB_Field {
 	public static function admin_enqueue_scripts(): void {
 		wp_enqueue_style( 'rwmb-link', RWMB_CSS_URL . 'link.css', [], RWMB_VER );
 		wp_style_add_data( 'rwmb-link', 'path', RWMB_CSS_DIR . 'link.css' );
-		wp_enqueue_script( 'rwmb-link', RWMB_JS_URL . 'link.js', [ 'jquery' ], RWMB_VER, true );
+		wp_enqueue_script( 'rwmb-link', RWMB_JS_URL . 'link.js', [ 'jquery', 'rwmb' ], RWMB_VER, true );
 		wp_localize_script( 'rwmb-link', 'rwmbLink', [
 			'editText'       => esc_html__( 'Edit', 'meta-box' ),
 			'removeText'     => esc_html__( 'Remove', 'meta-box' ),
@@ -54,7 +54,7 @@ class RWMB_Link_Field extends RWMB_Field {
 			$output .= '</div>';
 		} else {
 			$output .= '<div class="rwmb-link-display">';
-			$output .= '<a href="#" class="rwmb-link-select">' . esc_html__( 'Add link', 'meta-box' ) . '</a>';
+			$output .= '<button class="button rwmb-link-select">' . esc_html__( 'Add link', 'meta-box' ) . '</button>';
 			$output .= '</div>';
 		}
 

--- a/inc/fields/link.php
+++ b/inc/fields/link.php
@@ -35,10 +35,10 @@ class RWMB_Link_Field extends RWMB_Field {
 		$name = $field['field_name'];
 
 		$output  = '<div class="rwmb-link" data-field-name="' . esc_attr( $name ) . '">';
-		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[url]" value="' . esc_attr( $meta['url'] ) . '">';
-		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[title]" value="' . esc_attr( $meta['title'] ) . '">';
-		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[target]" value="' . esc_attr( $meta['target'] ) . '">';
-		$output .= '<input type="hidden" name="' . esc_attr( $name ) . '[post_id]" value="' . esc_attr( $meta['post_id'] ) . '">';
+		$output .= '<input type="hidden" class="rwmb-link-input" name="' . esc_attr( $name ) . '[url]" value="' . esc_attr( $meta['url'] ) . '">';
+		$output .= '<input type="hidden" class="rwmb-link-input" name="' . esc_attr( $name ) . '[title]" value="' . esc_attr( $meta['title'] ) . '">';
+		$output .= '<input type="hidden" class="rwmb-link-input" name="' . esc_attr( $name ) . '[target]" value="' . esc_attr( $meta['target'] ) . '">';
+		$output .= '<input type="hidden" class="rwmb-link-input" name="' . esc_attr( $name ) . '[post_id]" value="' . esc_attr( $meta['post_id'] ) . '">';
 
 		if ( $meta['url'] ) {
 			$output .= '<div class="rwmb-link-display">';

--- a/js/link.js
+++ b/js/link.js
@@ -15,10 +15,11 @@
 			return;
 		}
 
-		const $link     = $( e.target ).closest( '.rwmb-link' ),
-			$url       = $link.find( 'input[name$="[url]"]' ),
-			$title     = $link.find( 'input[name$="[title]"]' ),
-			$target    = $link.find( 'input[name$="[target]"]' );
+		const $link = $( e.target ).closest( '.rwmb-link' ),
+			$url    = $link.find( 'input[name$="[url]"]' ),
+			$title  = $link.find( 'input[name$="[title]"]' ),
+			$target = $link.find( 'input[name$="[target]"]' ),
+			$postId = $link.find( 'input[name$="[post_id]"]' );
 
 		wpLink.open( textareaId );
 
@@ -36,19 +37,16 @@
 			}
 
 			$url.val( attrs.href );
-			$target.val( attrs.target === '_blank' ? '_blank' : '' );
 			$title.val( $( '#wp-link-text' ).val() || attrs.href );
+			$target.val( attrs.target === '_blank' ? '_blank' : '' );
 
 			const postData = $( '#wp-link-wrap' ).data( 'selectedPost' );
-			$link.find( 'input[name$="[post_id]"]' ).val( postData && postData.ID ? postData.ID : 0 );
+			$postId.val( postData && postData.ID ? postData.ID : 0 );
 
-			const titleVal  = $title.val();
-			const targetVal = $target.val();
 			const $display  = $( '<span class="rwmb-link-text"></span>' );
-
 			$display.append( '<span class="dashicons dashicons-admin-links"></span> ' );
-			$display.append( $( '<a>', { href: attrs.href, target: '_blank', text: titleVal } ) );
-			if ( targetVal === '_blank' ) {
+			$display.append( $( '<a>', { href: attrs.href, target: '_blank', text: $title.val() } ) );
+			if ( $target.val() === '_blank' ) {
 				$display.append( ' <span class="rwmb-link-target">' + i18n.newTabText + '</span>' );
 			}
 

--- a/js/link.js
+++ b/js/link.js
@@ -47,7 +47,7 @@
 			$display.append( '<span class="dashicons dashicons-admin-links"></span> ' );
 			$display.append( $( '<a>', { href: attrs.href, target: '_blank', text: $title.val() } ) );
 			if ( $target.val() === '_blank' ) {
-				$display.append( ' <span class="rwmb-link-target">' + i18n.newTabText + '</span>' );
+				$display.append( `<span class="rwmb-link-target">${ i18n.newTabText }</span>` );
 			}
 
 			const $wrapper = $( '<div></div>' );
@@ -72,7 +72,7 @@
 		$link.find( 'input[name$="[title]"]' ).val( '' );
 		$link.find( 'input[name$="[target]"]' ).val( '' );
 		$link.find( 'input[name$="[post_id]"]' ).val( 0 );
-		$link.find( '.rwmb-link-display' ).html( '<button class="button rwmb-link-select">' + i18n.selectLinkText + '</button>' );
+		$link.find( '.rwmb-link-display' ).html( `<a href="#" class="rwmb-link-select">${ i18n.selectLinkText }</a>` );
 	} );
 
 } )( jQuery, rwmb, rwmbLink );

--- a/js/link.js
+++ b/js/link.js
@@ -1,0 +1,109 @@
+( ( $ ) => {
+	'use strict';
+
+	/**
+	 * Get or create a shared hidden textarea for wpLink.
+	 * wpLink.open() requires a textarea element with the given editor ID.
+	 */
+	const getLinkTextarea = () => {
+		let $textarea = $( '#rwmb-link-textarea' );
+		if ( ! $textarea.length ) {
+			$textarea = $( '<textarea id="rwmb-link-textarea" style="display:none"></textarea>' ).appendTo( 'body' );
+		}
+		return $textarea;
+	};
+
+	$( document ).on( 'click', '.rwmb-link-select, .rwmb-link-edit', ( e ) => {
+		e.preventDefault();
+
+		if ( typeof wpLink === 'undefined' ) {
+			return;
+		}
+
+		const $link     = $( e.target ).closest( '.rwmb-link' ),
+			$url       = $link.find( 'input[name$="[url]"]' ),
+			$title     = $link.find( 'input[name$="[title]"]' ),
+			$target    = $link.find( 'input[name$="[target]"]' ),
+			$textarea  = getLinkTextarea(),
+			origTitle  = $title.val();
+
+		wpLink.open( $textarea.attr( 'id' ) );
+
+		// Pre-fill the modal after it opens.
+		setTimeout( () => {
+			$( '#wp-link-url' ).val( $url.val() );
+			$( '#wp-link-text' ).val( origTitle );
+			$( '#wp-link-target' ).prop( 'checked', $target.val() === '_blank' );
+		}, 100 );
+
+		// Watch for URL changes from post search selections.
+		let lastUrl = $url.val();
+		const pollInterval = setInterval( () => {
+			const currentUrl = $( '#wp-link-url' ).val();
+			if ( currentUrl && currentUrl !== lastUrl ) {
+				lastUrl = currentUrl;
+				// Try to get title from selected search result, then selectedPost data.
+				let title = $( '#wp-link-wrap .query-results li.selected .item-title' ).text().trim()
+					|| $( '#wp-link-wrap' ).data( 'selectedPost' )
+					|| '';
+				if ( typeof title === 'object' && title.title ) {
+					title = title.title;
+				}
+				if ( title ) {
+					$( '#wp-link-text' ).val( title );
+				}
+			}
+		}, 100 );
+
+		$( '#wp-link-submit' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', () => {
+			clearInterval( pollInterval );
+
+			const attrs = wpLink.getAttrs();
+			if ( ! attrs.href ) {
+				return;
+			}
+
+			$url.val( attrs.href );
+			$target.val( attrs.target === '_blank' ? '_blank' : '' );
+			$title.val( $( '#wp-link-text' ).val() || attrs.href );
+
+			const postData = $( '#wp-link-wrap' ).data( 'selectedPost' );
+			$link.find( 'input[name$="[post_id]"]' ).val( postData && postData.ID ? postData.ID : 0 );
+
+			const titleVal  = $title.val();
+			const targetVal = $target.val();
+			const $display  = $( '<span class="rwmb-link-text"></span>' );
+
+			$display.append( '<span class="dashicons dashicons-admin-links"></span> ' );
+			$display.append( $( '<a>', { href: attrs.href, target: '_blank', text: titleVal } ) );
+			if ( targetVal === '_blank' ) {
+				$display.append( ' <span class="rwmb-link-target">' + rwmbLink.newTabText + '</span>' );
+			}
+
+			const $wrapper = $( '<div></div>' );
+			$wrapper.append( $display );
+			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-edit', text: rwmbLink.editText } ) );
+			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-remove', text: rwmbLink.removeText } ) );
+
+			$link.find( '.rwmb-link-display' ).empty().append( $wrapper.children() );
+			wpLink.close();
+		} );
+
+		$( '#wp-link-cancel' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', () => {
+			clearInterval( pollInterval );
+			wpLink.close();
+		} );
+	} );
+
+	$( document ).on( 'click', '.rwmb-link-remove', ( e ) => {
+		e.preventDefault();
+
+		const $link = $( e.target ).closest( '.rwmb-link' );
+		$link.find( 'input[name$="[url]"]' ).val( '' );
+		$link.find( 'input[name$="[title]"]' ).val( '' );
+		$link.find( 'input[name$="[target]"]' ).val( '' );
+		$link.find( 'input[name$="[post_id]"]' ).val( 0 );
+		$link.find( '.rwmb-link-display' ).html( '<a href="#" class="rwmb-link-select">' + rwmbLink.selectLinkText + '</a>' );
+	} );
+
+} )( jQuery );

--- a/js/link.js
+++ b/js/link.js
@@ -1,19 +1,14 @@
-( ( $ ) => {
+( ( $, rwmb, i18n ) => {
 	'use strict';
 
 	/**
 	 * Get or create a shared hidden textarea for wpLink.
 	 * wpLink.open() requires a textarea element with the given editor ID.
 	 */
-	const getLinkTextarea = () => {
-		let $textarea = $( '#rwmb-link-textarea' );
-		if ( ! $textarea.length ) {
-			$textarea = $( '<textarea id="rwmb-link-textarea" style="display:none"></textarea>' ).appendTo( 'body' );
-		}
-		return $textarea;
-	};
+	const textareaId = 'rwmb-link-textarea';
+	$( `<textarea id="${ textareaId }" style="display:none"></textarea>` ).appendTo( 'body' );
 
-	$( document ).on( 'click', '.rwmb-link-select, .rwmb-link-edit', ( e ) => {
+	rwmb.$document.on( 'click', '.rwmb-link-select, .rwmb-link-edit', ( e ) => {
 		e.preventDefault();
 
 		if ( typeof wpLink === 'undefined' ) {
@@ -23,41 +18,18 @@
 		const $link     = $( e.target ).closest( '.rwmb-link' ),
 			$url       = $link.find( 'input[name$="[url]"]' ),
 			$title     = $link.find( 'input[name$="[title]"]' ),
-			$target    = $link.find( 'input[name$="[target]"]' ),
-			$textarea  = getLinkTextarea(),
-			origTitle  = $title.val();
+			$target    = $link.find( 'input[name$="[target]"]' );
 
-		wpLink.open( $textarea.attr( 'id' ) );
+		wpLink.open( textareaId );
 
 		// Pre-fill the modal after it opens.
 		setTimeout( () => {
 			$( '#wp-link-url' ).val( $url.val() );
-			$( '#wp-link-text' ).val( origTitle );
+			$( '#wp-link-text' ).val( $title.val() );
 			$( '#wp-link-target' ).prop( 'checked', $target.val() === '_blank' );
 		}, 100 );
 
-		// Watch for URL changes from post search selections.
-		let lastUrl = $url.val();
-		const pollInterval = setInterval( () => {
-			const currentUrl = $( '#wp-link-url' ).val();
-			if ( currentUrl && currentUrl !== lastUrl ) {
-				lastUrl = currentUrl;
-				// Try to get title from selected search result, then selectedPost data.
-				let title = $( '#wp-link-wrap .query-results li.selected .item-title' ).text().trim()
-					|| $( '#wp-link-wrap' ).data( 'selectedPost' )
-					|| '';
-				if ( typeof title === 'object' && title.title ) {
-					title = title.title;
-				}
-				if ( title ) {
-					$( '#wp-link-text' ).val( title );
-				}
-			}
-		}, 100 );
-
 		$( '#wp-link-submit' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', () => {
-			clearInterval( pollInterval );
-
 			const attrs = wpLink.getAttrs();
 			if ( ! attrs.href ) {
 				return;
@@ -77,25 +49,24 @@
 			$display.append( '<span class="dashicons dashicons-admin-links"></span> ' );
 			$display.append( $( '<a>', { href: attrs.href, target: '_blank', text: titleVal } ) );
 			if ( targetVal === '_blank' ) {
-				$display.append( ' <span class="rwmb-link-target">' + rwmbLink.newTabText + '</span>' );
+				$display.append( ' <span class="rwmb-link-target">' + i18n.newTabText + '</span>' );
 			}
 
 			const $wrapper = $( '<div></div>' );
 			$wrapper.append( $display );
-			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-edit', text: rwmbLink.editText } ) );
-			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-remove', text: rwmbLink.removeText } ) );
+			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-edit', text: i18n.editText } ) );
+			$wrapper.append( $( '<a>', { href: '#', class: 'rwmb-link-remove', text: i18n.removeText } ) );
 
 			$link.find( '.rwmb-link-display' ).empty().append( $wrapper.children() );
 			wpLink.close();
 		} );
 
 		$( '#wp-link-cancel' ).off( 'click.rwmb-link' ).on( 'click.rwmb-link', () => {
-			clearInterval( pollInterval );
 			wpLink.close();
 		} );
 	} );
 
-	$( document ).on( 'click', '.rwmb-link-remove', ( e ) => {
+	rwmb.$document.on( 'click', '.rwmb-link-remove', ( e ) => {
 		e.preventDefault();
 
 		const $link = $( e.target ).closest( '.rwmb-link' );
@@ -103,7 +74,7 @@
 		$link.find( 'input[name$="[title]"]' ).val( '' );
 		$link.find( 'input[name$="[target]"]' ).val( '' );
 		$link.find( 'input[name$="[post_id]"]' ).val( 0 );
-		$link.find( '.rwmb-link-display' ).html( '<a href="#" class="rwmb-link-select">' + rwmbLink.selectLinkText + '</a>' );
+		$link.find( '.rwmb-link-display' ).html( '<button class="button rwmb-link-select">' + i18n.selectLinkText + '</button>' );
 	} );
 
-} )( jQuery );
+} )( jQuery, rwmb, rwmbLink );

--- a/tests/phpunit/LinkTest.php
+++ b/tests/phpunit/LinkTest.php
@@ -1,0 +1,124 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LinkTest extends TestCase {
+	public function testNormalize() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$field = RWMB_Link_Field::normalize( [
+			'type' => 'link',
+			'id'   => 'my_link',
+			'name' => 'My Link',
+		] );
+
+		$this->assertFalse( $field['multiple'] );
+		$this->assertEquals( 'link', $field['type'] );
+	}
+
+	public function testValueSanitizes() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$new = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '_blank',
+			'post_id' => '42',
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( 'https://example.com/test', $result['url'] );
+		$this->assertEquals( 'Test Link', $result['title'] );
+		$this->assertEquals( '_blank', $result['target'] );
+		$this->assertEquals( 42, $result['post_id'] );
+	}
+
+	public function testValueReturnsEmptyForEmptyInputs() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$new = [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( [], $result );
+	}
+
+	public function testValueRejectsInvalidTarget() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$new = [
+			'url'     => 'https://example.com',
+			'title'   => 'Link',
+			'target'  => 'invalid',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::value( $new, [], 1, [] );
+
+		$this->assertEquals( '', $result['target'] );
+	}
+
+	public function testFormatSingleValue() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$value = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '_blank',
+			'post_id' => 42,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '<a href="https://example.com/test" target="_blank">Test Link</a>', $result );
+	}
+
+	public function testFormatSingleValueNoTarget() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$value = [
+			'url'     => 'https://example.com/test',
+			'title'   => 'Test Link',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '<a href="https://example.com/test">Test Link</a>', $result );
+	}
+
+	public function testFormatSingleValueEmptyUrl() {
+		if ( ! defined( 'RWMB_VER' ) ) {
+			$this->markTestSkipped( 'Meta Box is not active' );
+		}
+
+		$value = [
+			'url'     => '',
+			'title'   => '',
+			'target'  => '',
+			'post_id' => 0,
+		];
+
+		$result = RWMB_Link_Field::format_single_value( [], $value, [], null );
+
+		$this->assertEquals( '', $result );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a dedicated `link` field type that provides ACF-compatible UX for selecting links. Uses WordPress's native Insert Link popup (`wpLink`) — the same one content editors already know from the post editor.

### What it does

- **Post linking**: Search and select internal posts/pages via the native link popup
- **Custom URLs**: Enter any external URL
- **Title**: Customize the link text
- **Open in new tab**: Simple checkbox for `_blank` target
- **Clone support**: Repeatable via Meta Box's clone mechanism
- **i18n**: All UI strings are translatable

### Data structure

Single serialized post meta array:
```php
['url' => '...', 'title' => '...', 'target' => '_blank', 'post_id' => 42]
```

### Front-end usage

```php
// Formatted <a> tag
rwmb_the_field( 'my_link' );

// Raw array
$link = rwmb_get_field( 'my_link' );
```

### Files

| File | Description |
|------|-------------|
| `inc/fields/link.php` | `RWMB_Link_Field` class |
| `js/link.js` | wpLink integration |
| `css/link.css` | Field styling |
| `tests/phpunit/LinkTest.php` | PHPUnit tests |

Fixes #1657