### PR TITLE
Fix: escape $object->label with esc_html() in input-list walker

### DIFF
--- a/inc/walkers/input-list.php
+++ b/inc/walkers/input-list.php
@@ -44,7 +44,7 @@ class RWMB_Walker_Input_List extends RWMB_Walker_Base {
 			RWMB_Field::render_attributes( $attributes ),
 			// phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 			checked( in_array( $object->value, $this->meta ), true, false ),
-			$object->label
+			esc_html( $object->label )
 		);
 	}
 }


### PR DESCRIPTION
Hey folks,

`start_el()` in the input-list walker outputs `$object->label` as the label text without escaping. The sibling `select.php` walker handles the identical value with `esc_html( $object->label )` — this brings `input-list.php` in line with that same pattern.

Term names and other label values that come from the database should be escaped before HTML output.

One-word change on one line.

(full disclosure, I used AI help with the testing and tweaks - Christopher)
