### PR TITLE
Fix: prevent invalid JSON in media field data attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 yarn.lock
 .DS_Store
 .idea
+.commandcode
 vendor
 .phpunit.result.cache
 .phpunit.cache

--- a/inc/fields/media.php
+++ b/inc/fields/media.php
@@ -132,7 +132,16 @@ class RWMB_Media_Field extends RWMB_File_Field {
 		$attributes['class'] .= ' rwmb-media';
 
 		// Add attachment details.
-		$attachments                    = array_values( array_filter( array_map( 'wp_prepare_attachment_for_js', $value ) ) );
+		$attachments = [];
+		foreach ( $value as $attachment_id ) {
+			$attachment = wp_prepare_attachment_for_js( $attachment_id );
+			if ( empty( $attachment ) ) {
+				continue;
+			}
+			// Do not load compat media HTML markup, which can cause invalid JSON
+			unset( $attachment['compat'] );
+			$attachments[] = $attachment;
+		}
 		$attributes['data-attachments'] = wp_json_encode( $attachments );
 
 		if ( empty( $attachments ) ) {


### PR DESCRIPTION
The `compat` key from `wp_prepare_attachment_for_js()` contains full HTML markup that can include invalid UTF-8 sequences and special characters, breaking `wp_json_encode()`. Remove this before encoding to ensure valid JSON in the data-attachments attribute.