### PR TITLE
Add independent Meta Box field block bindings source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,8 @@ pnpm run start
 - Follows **WordPress Coding Standards** (see `phpcs.xml`)
 - Uses **PSR-4** autoloading via Composer (`src/` directory)
 - Uses short array syntax `[]` (not `array()`)
-- Minimum PHP version: **7.1**
-- Minimum WordPress version: **6.5**
+- Minimum PHP version: **7.4**
+- Minimum WordPress version: **6.7**
 - Text domain: `meta-box`
 
 ### Naming Conventions

--- a/inc/field.php
+++ b/inc/field.php
@@ -301,6 +301,7 @@ abstract class RWMB_Field {
 			'field_name'        => $field['id'] ?? '',
 			'placeholder'       => '',
 			'save_field'        => true,
+			'block_bindings'    => false,
 
 			'clone'             => false,
 			'min_clone'         => 0,

--- a/inc/loader.php
+++ b/inc/loader.php
@@ -119,6 +119,7 @@ class RWMB_Loader {
 
 		// Register categories for page builders.
 		new \MetaBox\Integrations\Block();
+		new \MetaBox\Integrations\BlockBindings();
 		new \MetaBox\Integrations\Bricks();
 		new \MetaBox\Integrations\Elementor();
 		new \MetaBox\Integrations\Oxygen();

--- a/js/block-bindings.js
+++ b/js/block-bindings.js
@@ -5,13 +5,8 @@
 		return;
 	}
 
-	// The front-end value is resolved in PHP. In the editor we only expose the
-	// fields list so the source appears in the block bindings UI. Bound blocks
-	// show their placeholder until the post is viewed on the front end.
-	//
-	// getValues is required by the editor even though we have no client-side
-	// value (the field data is not exposed via REST). Return an empty object so
-	// the bindings UI renders without previewing a value.
+	// The front-end value is resolved in PHP; the editor only exposes the fields list so the source appears in the bindings UI.
+	// getValues is required by the editor, but there is no client-side value (fields are not exposed via REST), so it returns {}.
 	wp.blocks.registerBlockBindingsSource( {
 		name: 'meta-box/field',
 		label: wp.i18n.__( 'Meta Box Field', 'meta-box' ),

--- a/js/block-bindings.js
+++ b/js/block-bindings.js
@@ -1,0 +1,20 @@
+( function ( wp, data ) {
+	'use strict';
+
+	if ( ! wp?.blocks?.registerBlockBindingsSource || ! data?.fields ) {
+		return;
+	}
+
+	// The front-end value is resolved in PHP. In the editor we only expose the
+	// fields list so the source appears in the block bindings UI. Bound blocks
+	// show their placeholder until the post is viewed on the front end.
+	wp.blocks.registerBlockBindingsSource( {
+		name: 'meta-box/field',
+		label: wp.i18n.__( 'Meta Box Field', 'meta-box' ),
+		usesContext: [ 'postId', 'postType' ],
+		getFieldsList( { context } ) {
+			return data.fields[ context?.postType ] || [];
+		},
+		canUserEditValue: () => false,
+	} );
+} )( window.wp, window.rwmbBlockBindings );

--- a/js/block-bindings.js
+++ b/js/block-bindings.js
@@ -8,12 +8,19 @@
 	// The front-end value is resolved in PHP. In the editor we only expose the
 	// fields list so the source appears in the block bindings UI. Bound blocks
 	// show their placeholder until the post is viewed on the front end.
+	//
+	// getValues is required by the editor even though we have no client-side
+	// value (the field data is not exposed via REST). Return an empty object so
+	// the bindings UI renders without previewing a value.
 	wp.blocks.registerBlockBindingsSource( {
 		name: 'meta-box/field',
 		label: wp.i18n.__( 'Meta Box Field', 'meta-box' ),
 		usesContext: [ 'postId', 'postType' ],
 		getFieldsList( { context } ) {
 			return data.fields[ context?.postType ] || [];
+		},
+		getValues() {
+			return {};
 		},
 		canUserEditValue: () => false,
 	} );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -78,7 +78,7 @@
 	<!-- Set the minimum supported WP version. This is used by several sniffs.
 		 The minimum version set here should be in line with the minimum WP version
 		 as set in the "Requires at least" tag in the readme.txt file. -->
-	<config name="minimum_supported_wp_version" value="6.5"/>
+	<config name="minimum_supported_wp_version" value="6.7"/>
 
 	<!--
 	#############################################################################

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: elightup, metabox, rilwis, f-j-kaiser, funkatronic, PerWiklander, ruanmer, tanng
 Donate link: https://metabox.io/pricing/
 Tags: custom fields, custom post types, post type, custom taxonomies, meta box
-Requires at least: 6.6
+Requires at least: 6.7
 Requires PHP: 7.4
 Tested up to: 7.0.1
 Stable tag: 5.13.1

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -13,21 +13,19 @@ use WP_Block;
 class BlockBindings {
 	public const SOURCE_NAME = 'meta-box/field';
 
-	/**
-	 * Fields storing attachment IDs. Their value can map to url/id/alt/title/caption.
-	 */
-	private const ATTACHMENT_TYPES = [
-		'single_image',
-		'image',
-		'image_advanced',
-		'image_upload',
-		'file',
-		'file_advanced',
-		'file_upload',
-		'video',
+	private const IMAGE_TYPES = [ 'single_image', 'image', 'image_advanced', 'image_upload' ];
+	private const FILE_TYPES  = [ 'file', 'file_advanced', 'file_upload' ];
+	private const VALUE_KEYS  = [
+		'background'        => [ 'image' ],
+		'link'              => [ 'url', 'title', 'target' ],
+		'map'               => [ 'latitude', 'longitude' ],
+		'osm'               => [ 'latitude', 'longitude' ],
+		'post'              => [ 'post_title', 'post_excerpt', 'post_content', 'post_date', 'post_modified', 'post_author', 'url' ],
+		'taxonomy'          => [ 'name', 'slug', 'description', 'url' ],
+		'taxonomy_advanced' => [ 'name', 'slug', 'description', 'url' ],
+		'user'              => [ 'display_name', 'user_url' ],
+		'video'             => [ 'src', 'title', 'caption', 'description' ],
 	];
-
-	private const NUMERIC_TYPES = [ 'number', 'range', 'slider' ];
 
 	public function __construct() {
 		add_action( 'init', [ $this, 'register' ] );
@@ -51,7 +49,9 @@ class BlockBindings {
 
 	/**
 	 * Fields (opted in via `block_bindings`) for the editor UI, keyed by post type.
-	 * Attachment fields are listed as both string (url/alt/…) and number (id).
+	 *
+	 * Structured fields (image, map, post, user, …) expose selectable value keys
+	 * via `args.key`. Scalar fields are listed once as `string`.
 	 *
 	 * @return array<string, array>
 	 */
@@ -65,14 +65,8 @@ class BlockBindings {
 					continue;
 				}
 
-				$item = [
-					'label' => $field['name'] ?: $field['id'],
-					'args'  => [ 'id' => $field['id'] ],
-				];
-
-				$types = self::attribute_types( $field['type'] );
-				foreach ( $types as $type ) {
-					$result[ $post_type ][] = $item + [ 'type' => $type ];
+				foreach ( self::binding_options( $field ) as $option ) {
+					$result[ $post_type ][] = $option;
 				}
 			}
 		}
@@ -81,26 +75,98 @@ class BlockBindings {
 	}
 
 	/**
-	 * Block attribute types a field can bind to.
+	 * Binding options for one field (label + type + args).
 	 *
-	 * @return string[]
+	 * @return list<array{label: string, type: string, args: array{id: string, key?: string}}>
 	 */
-	private static function attribute_types( string $field_type ): array {
-		if ( in_array( $field_type, self::ATTACHMENT_TYPES, true ) ) {
-			return [ 'string', 'number' ];
+	private static function binding_options( array $field ): array {
+		$name = $field['name'] ?: $field['id'];
+		$id   = $field['id'];
+
+		if ( in_array( $field['type'], self::IMAGE_TYPES, true ) ) {
+			return self::value_key_options( $name, $id, [ 'url', 'alt', 'title', 'caption', 'description' ] );
 		}
-		if ( in_array( $field_type, self::NUMERIC_TYPES, true ) ) {
-			return [ 'string', 'number' ];
+
+		if ( in_array( $field['type'], self::FILE_TYPES, true ) ) {
+			return self::value_key_options( $name, $id, [ 'url', 'title' ] );
 		}
-		return [ 'string' ];
+
+		// Keys come from the field's options config (associative array value).
+		if ( 'fieldset_text' === $field['type'] && ! empty( $field['options'] ) && is_array( $field['options'] ) ) {
+			return self::value_key_options( $name, $id, array_keys( $field['options'] ), $field['options'] );
+		}
+
+		if ( isset( self::VALUE_KEYS[ $field['type'] ] ) ) {
+			return self::value_key_options( $name, $id, self::VALUE_KEYS[ $field['type'] ] );
+		}
+
+		return [
+			[
+				'label' => $name,
+				'type'  => 'string',
+				'args'  => [ 'id' => $id ],
+			],
+		];
+	}
+
+	/**
+	 * @param string   $name   Field label.
+	 * @param string   $id     Field id.
+	 * @param string[] $keys   Value keys to expose (url, alt, id, …).
+	 * @param string[] $labels Optional labels keyed by value key.
+	 * @return list<array{label: string, type: string, args: array{id: string, key: string}}>
+	 */
+	private static function value_key_options( string $name, string $id, array $keys, array $labels = [] ): array {
+		$options = [];
+		foreach ( $keys as $key ) {
+			$label = $labels[ $key ] ?? self::value_key_label( $key );
+			$options[] = [
+				// translators: 1: field name, 2: value property (URL, Caption, …).
+				'label' => sprintf( __( '%1$s: %2$s', 'meta-box' ), $name, wp_strip_all_tags( $label ) ),
+				'type'  => 'string',
+				'args'  => [
+					'id'  => $id,
+					'key' => $key,
+				],
+			];
+		}
+
+		return $options;
+	}
+
+	private static function value_key_label( string $key ): string {
+		$labels = [
+			'url'           => __( 'URL', 'meta-box' ),
+			'alt'           => __( 'Alt Text', 'meta-box' ),
+			'title'         => __( 'Title', 'meta-box' ),
+			'caption'       => __( 'Caption', 'meta-box' ),
+			'description'   => __( 'Description', 'meta-box' ),
+			'name'          => __( 'Name', 'meta-box' ),
+			'src'           => __( 'Source URL', 'meta-box' ),
+			'latitude'      => __( 'Latitude', 'meta-box' ),
+			'longitude'     => __( 'Longitude', 'meta-box' ),
+			'image'         => __( 'Image', 'meta-box' ),
+			'target'        => __( 'Target', 'meta-box' ),
+			'post_title'    => __( 'Title', 'meta-box' ),
+			'post_excerpt'  => __( 'Excerpt', 'meta-box' ),
+			'post_content'  => __( 'Content', 'meta-box' ),
+			'post_date'     => __( 'Published Date', 'meta-box' ),
+			'post_modified' => __( 'Modified Date', 'meta-box' ),
+			'post_author'   => __( 'Author', 'meta-box' ),
+			'slug'          => __( 'Slug', 'meta-box' ),
+			'display_name'  => __( 'Display Name', 'meta-box' ),
+			'user_url'      => __( 'URL', 'meta-box' ),
+		];
+
+		return $labels[ $key ] ?? $key;
 	}
 
 	/**
 	 * Resolve the field value for a bound block attribute (front-end render).
 	 *
-	 * @param array     $source_args    Expects `id` (field id).
-	 * @param WP_Block  $block_instance Block instance.
-	 * @param string    $attribute_name Bound attribute.
+	 * @param array    $source_args    Expects `id` (field id), optional `key` (value property).
+	 * @param WP_Block $block_instance Block instance.
+	 * @param string   $attribute_name Bound block attribute.
 	 * @return mixed
 	 */
 	public function get_value( array $source_args, WP_Block $block_instance, string $attribute_name ) {
@@ -131,7 +197,11 @@ class BlockBindings {
 			return null;
 		}
 
-		return self::format_for_attribute( $value, $attribute_name );
+		// `key` selects which part of any structured value to use.
+		// Falls back to the bound block attribute name (e.g. Image block `url`).
+		$key = $source_args['key'] ?? $attribute_name;
+
+		return self::format_value( $value, $field, $key );
 	}
 
 	/**
@@ -158,25 +228,49 @@ class BlockBindings {
 	}
 
 	/**
-	 * Map a single field value to the bound block attribute.
+	 * Map a single field value to the requested key / block attribute.
 	 *
-	 * @param mixed  $value          Single field value.
-	 * @param string $attribute_name Block attribute.
+	 * @param mixed  $value Single field value.
+	 * @param array  $field Field settings.
+	 * @param string $key   Value key or block attribute name.
 	 * @return mixed
 	 */
-	private static function format_for_attribute( $value, string $attribute_name ) {
-		if ( is_array( $value ) ) {
-			if ( 'id' === $attribute_name ) {
-				return isset( $value['ID'] ) ? (float) $value['ID'] : null;
+	private static function format_value( $value, array $field, string $key ) {
+		if ( 'post' === $field['type'] ) {
+			$post = get_post( $value );
+			if ( ! $post ) {
+				return null;
 			}
-			if ( in_array( $attribute_name, [ 'url', 'href' ], true ) ) {
-				return $value['full_url'] ?? $value['url'] ?? null;
+			if ( 'url' === $key ) {
+				return get_permalink( $post );
 			}
-			return isset( $value[ $attribute_name ] ) ? (string) $value[ $attribute_name ] : null;
+			if ( 'post_author' === $key ) {
+				return get_the_author_meta( 'display_name', $post->post_author );
+			}
+			$value = $post;
 		}
 
-		if ( 'id' === $attribute_name && is_numeric( $value ) ) {
-			return (float) $value;
+		if ( 'user' === $field['type'] ) {
+			$value = get_userdata( $value );
+		}
+
+		if ( in_array( $field['type'], [ 'taxonomy', 'taxonomy_advanced' ], true ) && 'url' === $key ) {
+			$url = get_term_link( $value );
+			return is_wp_error( $url ) ? null : $url;
+		}
+
+		if ( is_object( $value ) ) {
+			$value = $value->$key ?? null;
+			return is_scalar( $value ) ? (string) $value : null;
+		}
+
+		if ( is_array( $value ) ) {
+			// Image uses full_url/url; video uses src.
+			if ( in_array( $key, [ 'url', 'href' ], true ) ) {
+				return $value['full_url'] ?? $value['url'] ?? $value['src'] ?? null;
+			}
+			$value = $value[ $key ] ?? null;
+			return is_scalar( $value ) ? (string) $value : null;
 		}
 
 		return is_scalar( $value ) ? (string) $value : null;

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -184,9 +184,7 @@ class BlockBindings {
 		}
 
 		// Reuse the already-fetched $field instead of rwmb_get_value(), which would look it up again.
-		$value = RWMB_Field::call( 'get_value', $field, $args, $post_id );
-		$value = apply_filters( 'rwmb_get_value', $value, $field, $args, $post_id );
-		$value = $this->get_single_value( $value, $field );
+		$value = $this->get_single_value( RWMB_Field::call( 'get_value', $field, $args, $post_id ), $field );
 		if ( $this->is_empty( $value ) ) {
 			return null;
 		}

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -1,6 +1,7 @@
 <?php
 namespace MetaBox\Integrations;
 
+use RWMB_Field;
 use WP_Block;
 
 /**
@@ -182,7 +183,10 @@ class BlockBindings {
 			return null;
 		}
 
-		$value = $this->get_single_value( rwmb_get_value( $field_id, $args, $post_id ), $field );
+		// Reuse the already-fetched $field instead of rwmb_get_value(), which would look it up again.
+		$value = RWMB_Field::call( 'get_value', $field, $args, $post_id );
+		$value = apply_filters( 'rwmb_get_value', $value, $field, $args, $post_id );
+		$value = $this->get_single_value( $value, $field );
 		if ( $this->is_empty( $value ) ) {
 			return null;
 		}
@@ -237,6 +241,9 @@ class BlockBindings {
 
 		if ( 'user' === $field['type'] ) {
 			$value = get_userdata( $value );
+			if ( ! $value ) {
+				return null;
+			}
 		}
 
 		if ( in_array( $field['type'], [ 'taxonomy', 'taxonomy_advanced' ], true ) && 'url' === $key ) {

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -45,9 +45,14 @@ class BlockBindings {
 	}
 
 	public function enqueue(): void {
+		$fields = $this->get_editor_fields();
+		if ( ! $fields ) {
+			return;
+		}
+
 		wp_enqueue_script( 'rwmb-block-bindings', RWMB_JS_URL . 'block-bindings.js', [ 'wp-blocks', 'wp-i18n' ], RWMB_VER, true );
 		wp_localize_script( 'rwmb-block-bindings', 'rwmbBlockBindings', [
-			'fields' => $this->get_editor_fields(),
+			'fields' => $fields,
 		] );
 	}
 
@@ -229,7 +234,7 @@ class BlockBindings {
 				return null;
 			}
 			if ( 'url' === $key ) {
-				return get_permalink( $post );
+				return esc_url( get_permalink( $post ) );
 			}
 			if ( 'post_author' === $key ) {
 				return get_the_author_meta( 'display_name', $post->post_author );

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -7,15 +7,18 @@ use WP_Block;
  * Register a custom block bindings source: meta-box/field.
  *
  * Fields opt in with `'block_bindings' => true`.
- * The front-end value is resolved in PHP.
- * The editor only needs the fields list to show the source in the block bindings UI.
+ * The front-end value is resolved in PHP; the editor only needs the fields list to show the source in the bindings UI.
  */
 class BlockBindings {
 	public const SOURCE_NAME = 'meta-box/field';
-
-	private const IMAGE_TYPES = [ 'single_image', 'image', 'image_advanced', 'image_upload' ];
-	private const FILE_TYPES  = [ 'file', 'file_advanced', 'file_upload' ];
-	private const VALUE_KEYS  = [
+	private const VALUE_KEYS = [
+		'single_image'      => [ 'url', 'alt', 'title', 'caption', 'description' ],
+		'image'             => [ 'url', 'alt', 'title', 'caption', 'description' ],
+		'image_advanced'    => [ 'url', 'alt', 'title', 'caption', 'description' ],
+		'image_upload'      => [ 'url', 'alt', 'title', 'caption', 'description' ],
+		'file'              => [ 'url', 'title' ],
+		'file_advanced'     => [ 'url', 'title' ],
+		'file_upload'       => [ 'url', 'title' ],
 		'background'        => [ 'image' ],
 		'link'              => [ 'url', 'title', 'target' ],
 		'map'               => [ 'latitude', 'longitude' ],
@@ -50,8 +53,8 @@ class BlockBindings {
 	/**
 	 * Fields (opted in via `block_bindings`) for the editor UI, keyed by post type.
 	 *
-	 * Structured fields (image, map, post, user, …) expose selectable value keys
-	 * via `args.key`. Scalar fields are listed once as `string`.
+	 * Structured fields (image, map, post, user, …) expose selectable value keys via `args.key`.
+	 * Scalar fields are listed once as `string`.
 	 *
 	 * @return array<string, array>
 	 */
@@ -64,10 +67,7 @@ class BlockBindings {
 				if ( empty( $field['id'] ) || empty( $field['block_bindings'] ) ) {
 					continue;
 				}
-
-				foreach ( self::binding_options( $field ) as $option ) {
-					$result[ $post_type ][] = $option;
-				}
+				$result[ $post_type ] = array_merge( $result[ $post_type ] ?? [], $this->binding_options( $field ) );
 			}
 		}
 
@@ -79,25 +79,17 @@ class BlockBindings {
 	 *
 	 * @return list<array{label: string, type: string, args: array{id: string, key?: string}}>
 	 */
-	private static function binding_options( array $field ): array {
+	private function binding_options( array $field ): array {
 		$name = $field['name'] ?: $field['id'];
 		$id   = $field['id'];
 
-		if ( in_array( $field['type'], self::IMAGE_TYPES, true ) ) {
-			return self::value_key_options( $name, $id, [ 'url', 'alt', 'title', 'caption', 'description' ] );
-		}
-
-		if ( in_array( $field['type'], self::FILE_TYPES, true ) ) {
-			return self::value_key_options( $name, $id, [ 'url', 'title' ] );
-		}
-
-		// Keys come from the field's options config (associative array value).
+		// Keys come from the field's options config.
 		if ( 'fieldset_text' === $field['type'] && ! empty( $field['options'] ) && is_array( $field['options'] ) ) {
-			return self::value_key_options( $name, $id, array_keys( $field['options'] ), $field['options'] );
+			return $this->value_key_options( $name, $id, array_keys( $field['options'] ), $field['options'] );
 		}
 
 		if ( isset( self::VALUE_KEYS[ $field['type'] ] ) ) {
-			return self::value_key_options( $name, $id, self::VALUE_KEYS[ $field['type'] ] );
+			return $this->value_key_options( $name, $id, self::VALUE_KEYS[ $field['type'] ] );
 		}
 
 		return [
@@ -112,14 +104,14 @@ class BlockBindings {
 	/**
 	 * @param string   $name   Field label.
 	 * @param string   $id     Field id.
-	 * @param string[] $keys   Value keys to expose (url, alt, id, …).
+	 * @param string[] $keys   Value keys to expose (url, alt, caption, …).
 	 * @param string[] $labels Optional labels keyed by value key.
 	 * @return list<array{label: string, type: string, args: array{id: string, key: string}}>
 	 */
-	private static function value_key_options( string $name, string $id, array $keys, array $labels = [] ): array {
+	private function value_key_options( string $name, string $id, array $keys, array $labels = [] ): array {
 		$options = [];
 		foreach ( $keys as $key ) {
-			$label = $labels[ $key ] ?? self::value_key_label( $key );
+			$label     = $labels[ $key ] ?? $this->value_key_label( $key );
 			$options[] = [
 				// translators: 1: field name, 2: value property (URL, Caption, …).
 				'label' => sprintf( __( '%1$s: %2$s', 'meta-box' ), $name, wp_strip_all_tags( $label ) ),
@@ -134,7 +126,7 @@ class BlockBindings {
 		return $options;
 	}
 
-	private static function value_key_label( string $key ): string {
+	private function value_key_label( string $key ): string {
 		$labels = [
 			'url'           => __( 'URL', 'meta-box' ),
 			'alt'           => __( 'Alt Text', 'meta-box' ),
@@ -164,7 +156,7 @@ class BlockBindings {
 	/**
 	 * Resolve the field value for a bound block attribute (front-end render).
 	 *
-	 * @param array    $source_args    Expects `id` (field id), optional `key` (value property).
+	 * @param array    $source_args    Field id and optional value key.
 	 * @param WP_Block $block_instance Block instance.
 	 * @param string   $attribute_name Bound block attribute.
 	 * @return mixed
@@ -190,18 +182,13 @@ class BlockBindings {
 			return null;
 		}
 
-		$value = rwmb_get_value( $field_id, $args, $post_id );
-		$value = self::get_single_value( $value, $field );
-
-		if ( null === $value || '' === $value || false === $value ) {
+		$value = $this->get_single_value( rwmb_get_value( $field_id, $args, $post_id ), $field );
+		if ( $this->is_empty( $value ) ) {
 			return null;
 		}
 
-		// `key` selects which part of any structured value to use.
-		// Falls back to the bound block attribute name (e.g. Image block `url`).
-		$key = $source_args['key'] ?? $attribute_name;
-
-		return self::format_value( $value, $field, $key );
+		// `key` picks a part of a structured value, falling back to the bound attribute name (e.g. Image block `url`).
+		return $this->format_value( $value, $field, $source_args['key'] ?? $attribute_name );
 	}
 
 	/**
@@ -211,17 +198,15 @@ class BlockBindings {
 	 * @param array $field Field settings.
 	 * @return mixed
 	 */
-	private static function get_single_value( $value, array $field ) {
-		if ( $field['clone'] ) {
+	private function get_single_value( $value, array $field ) {
+		foreach ( [ 'clone', 'multiple' ] as $prop ) {
+			if ( ! $field[ $prop ] ) {
+				continue;
+			}
 			$value = is_array( $value ) && $value ? reset( $value ) : null;
-		}
-
-		if ( null === $value || '' === $value || false === $value ) {
-			return null;
-		}
-
-		if ( $field['multiple'] ) {
-			$value = is_array( $value ) && $value ? reset( $value ) : null;
+			if ( $this->is_empty( $value ) ) {
+				return null;
+			}
 		}
 
 		return $value;
@@ -235,7 +220,7 @@ class BlockBindings {
 	 * @param string $key   Value key or block attribute name.
 	 * @return mixed
 	 */
-	private static function format_value( $value, array $field, string $key ) {
+	private function format_value( $value, array $field, string $key ) {
 		if ( 'post' === $field['type'] ) {
 			$post = get_post( $value );
 			if ( ! $post ) {
@@ -260,19 +245,25 @@ class BlockBindings {
 		}
 
 		if ( is_object( $value ) ) {
-			$value = $value->$key ?? null;
-			return is_scalar( $value ) ? (string) $value : null;
+			return $this->to_string( $value->$key ?? null );
 		}
 
 		if ( is_array( $value ) ) {
 			// Image uses full_url/url; video uses src.
 			if ( in_array( $key, [ 'url', 'href' ], true ) ) {
-				return $value['full_url'] ?? $value['url'] ?? $value['src'] ?? null;
+				return $this->to_string( $value['full_url'] ?? $value['url'] ?? $value['src'] ?? null );
 			}
-			$value = $value[ $key ] ?? null;
-			return is_scalar( $value ) ? (string) $value : null;
+			return $this->to_string( $value[ $key ] ?? null );
 		}
 
+		return $this->to_string( $value );
+	}
+
+	private function is_empty( $value ): bool {
+		return null === $value || '' === $value || false === $value;
+	}
+
+	private function to_string( $value ): ?string {
 		return is_scalar( $value ) ? (string) $value : null;
 	}
 }

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -247,11 +247,15 @@ class BlockBindings {
 			if ( ! $value ) {
 				return null;
 			}
+			// user_url is user-controlled, so escape it as a URL.
+			if ( 'user_url' === $key ) {
+				return esc_url( $value->user_url );
+			}
 		}
 
 		if ( in_array( $field['type'], [ 'taxonomy', 'taxonomy_advanced' ], true ) && 'url' === $key ) {
 			$url = get_term_link( $value );
-			return is_wp_error( $url ) ? null : $url;
+			return is_wp_error( $url ) ? null : esc_url( $url );
 		}
 
 		if ( is_object( $value ) ) {

--- a/src/Integrations/BlockBindings.php
+++ b/src/Integrations/BlockBindings.php
@@ -1,0 +1,184 @@
+<?php
+namespace MetaBox\Integrations;
+
+use WP_Block;
+
+/**
+ * Register a custom block bindings source: meta-box/field.
+ *
+ * Fields opt in with `'block_bindings' => true`.
+ * The front-end value is resolved in PHP.
+ * The editor only needs the fields list to show the source in the block bindings UI.
+ */
+class BlockBindings {
+	public const SOURCE_NAME = 'meta-box/field';
+
+	/**
+	 * Fields storing attachment IDs. Their value can map to url/id/alt/title/caption.
+	 */
+	private const ATTACHMENT_TYPES = [
+		'single_image',
+		'image',
+		'image_advanced',
+		'image_upload',
+		'file',
+		'file_advanced',
+		'file_upload',
+		'video',
+	];
+
+	private const NUMERIC_TYPES = [ 'number', 'range', 'slider' ];
+
+	public function __construct() {
+		add_action( 'init', [ $this, 'register' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue' ] );
+	}
+
+	public function register(): void {
+		register_block_bindings_source( self::SOURCE_NAME, [
+			'label'              => __( 'Meta Box Field', 'meta-box' ),
+			'get_value_callback' => [ $this, 'get_value' ],
+			'uses_context'       => [ 'postId', 'postType' ],
+		] );
+	}
+
+	public function enqueue(): void {
+		wp_enqueue_script( 'rwmb-block-bindings', RWMB_JS_URL . 'block-bindings.js', [ 'wp-blocks', 'wp-i18n' ], RWMB_VER, true );
+		wp_localize_script( 'rwmb-block-bindings', 'rwmbBlockBindings', [
+			'fields' => $this->get_editor_fields(),
+		] );
+	}
+
+	/**
+	 * Fields (opted in via `block_bindings`) for the editor UI, keyed by post type.
+	 * Attachment fields are listed as both string (url/alt/…) and number (id).
+	 *
+	 * @return array<string, array>
+	 */
+	private function get_editor_fields(): array {
+		$result      = [];
+		$post_fields = rwmb_get_registry( 'field' )->get_by_object_type( 'post' );
+
+		foreach ( $post_fields as $post_type => $fields ) {
+			foreach ( $fields as $field ) {
+				if ( empty( $field['id'] ) || empty( $field['block_bindings'] ) ) {
+					continue;
+				}
+
+				$item = [
+					'label' => $field['name'] ?: $field['id'],
+					'args'  => [ 'id' => $field['id'] ],
+				];
+
+				$types = self::attribute_types( $field['type'] );
+				foreach ( $types as $type ) {
+					$result[ $post_type ][] = $item + [ 'type' => $type ];
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Block attribute types a field can bind to.
+	 *
+	 * @return string[]
+	 */
+	private static function attribute_types( string $field_type ): array {
+		if ( in_array( $field_type, self::ATTACHMENT_TYPES, true ) ) {
+			return [ 'string', 'number' ];
+		}
+		if ( in_array( $field_type, self::NUMERIC_TYPES, true ) ) {
+			return [ 'string', 'number' ];
+		}
+		return [ 'string' ];
+	}
+
+	/**
+	 * Resolve the field value for a bound block attribute (front-end render).
+	 *
+	 * @param array     $source_args    Expects `id` (field id).
+	 * @param WP_Block  $block_instance Block instance.
+	 * @param string    $attribute_name Bound attribute.
+	 * @return mixed
+	 */
+	public function get_value( array $source_args, WP_Block $block_instance, string $attribute_name ) {
+		$field_id = $source_args['id'] ?? '';
+		$post_id  = (int) ( $block_instance->context['postId'] ?? 0 );
+		if ( ! $field_id || ! $post_id ) {
+			return null;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || post_password_required( $post ) || ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) ) {
+			return null;
+		}
+
+		$args  = [
+			'object_type' => 'post',
+			'type'        => $block_instance->context['postType'] ?? '',
+		];
+		$field = rwmb_get_field_settings( $field_id, $args, $post_id );
+		if ( ! $field || empty( $field['block_bindings'] ) ) {
+			return null;
+		}
+
+		$value = rwmb_get_value( $field_id, $args, $post_id );
+		$value = self::get_single_value( $value, $field );
+
+		if ( null === $value || '' === $value || false === $value ) {
+			return null;
+		}
+
+		return self::format_for_attribute( $value, $attribute_name );
+	}
+
+	/**
+	 * Reduce clone / multiple values to a single unit value.
+	 *
+	 * @param mixed $value Value from rwmb_get_value().
+	 * @param array $field Field settings.
+	 * @return mixed
+	 */
+	private static function get_single_value( $value, array $field ) {
+		if ( $field['clone'] ) {
+			$value = is_array( $value ) && $value ? reset( $value ) : null;
+		}
+
+		if ( null === $value || '' === $value || false === $value ) {
+			return null;
+		}
+
+		if ( $field['multiple'] ) {
+			$value = is_array( $value ) && $value ? reset( $value ) : null;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Map a single field value to the bound block attribute.
+	 *
+	 * @param mixed  $value          Single field value.
+	 * @param string $attribute_name Block attribute.
+	 * @return mixed
+	 */
+	private static function format_for_attribute( $value, string $attribute_name ) {
+		if ( is_array( $value ) ) {
+			if ( 'id' === $attribute_name ) {
+				return isset( $value['ID'] ) ? (float) $value['ID'] : null;
+			}
+			if ( in_array( $attribute_name, [ 'url', 'href' ], true ) ) {
+				return $value['full_url'] ?? $value['url'] ?? null;
+			}
+			return isset( $value[ $attribute_name ] ) ? (string) $value[ $attribute_name ] : null;
+		}
+
+		if ( 'id' === $attribute_name && is_numeric( $value ) ) {
+			return (float) $value;
+		}
+
+		return is_scalar( $value ) ? (string) $value : null;
+	}
+}


### PR DESCRIPTION
## Summary
- Register a custom `meta-box/field` block bindings source so fields can opt in with `block_bindings => true`, independent of `register_meta`
- Resolve front-end values in PHP (clone/multiple unwrap, structured keys for image/file/post/user/map/etc.) and expose a filtered fields list in the editor UI
- Include the required client-side `getValues` stub so the block editor does not crash

## Test plan
- [x] Enable `block_bindings => true` on a text field and bind it to a Paragraph/Heading block; confirm the value renders on the front end
- [x] Enable it on `single_image` and bind Image block `url` / `alt` / `caption`; confirm only suitable options appear per block attribute type
- [x] Try post/user/map/link fields and confirm selectable value keys (e.g. `post_title`, `display_name`, `latitude`) resolve correctly
- [x] Confirm clone/multiple fields use the first item only
- [x] Open Site Editor / post editor and confirm no `source.getValues is not a function` error
- [x] Confirm fields without `block_bindings` do not appear in the bindings UI and are not resolved


Made with [Cursor](https://cursor.com)